### PR TITLE
ID attribute fix

### DIFF
--- a/com/onelogin/saml/Response.java
+++ b/com/onelogin/saml/Response.java
@@ -50,24 +50,24 @@ public class Response {
 		loadXml(decodedS);	
 	}
 	
-	public boolean isValid() throws Exception {
-		NodeList nodes = xmlDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
-								
-		if(nodes==null || nodes.getLength()==0){
-            throw new Exception("Can't find signature in document.");
+        public boolean isValid() throws Exception {
+            NodeList nodes = xmlDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
+
+            if (nodes == null || nodes.getLength() == 0) {
+                throw new Exception("Can't find signature in document.");
+            }
+
+            if (setIdAttributeExists()) {
+                tagIdAttributes(xmlDoc);
+            }
+
+            X509Certificate cert = certificate.getX509Cert();
+            DOMValidateContext ctx = new DOMValidateContext(cert.getPublicKey(), nodes.item(0));
+            XMLSignatureFactory sigF = XMLSignatureFactory.getInstance("DOM");
+            XMLSignature xmlSignature = sigF.unmarshalXMLSignature(ctx);
+
+            return xmlSignature.validate(ctx);
         }
-
-        if (setIdAttributeExists()) {
-            tagIdAttributes(xmlDoc);
-        }
-
-        X509Certificate cert = certificate.getX509Cert();
-		DOMValidateContext ctx = new DOMValidateContext(cert.getPublicKey() , nodes.item(0));				
-        XMLSignatureFactory sigF = XMLSignatureFactory.getInstance("DOM");
-        XMLSignature xmlSignature = sigF.unmarshalXMLSignature(ctx);
-
-        return xmlSignature.validate(ctx);
-    }
 	
 	public String getNameId() throws Exception {
 		NodeList nodes = xmlDoc.getElementsByTagNameNS("urn:oasis:names:tc:SAML:2.0:assertion", "NameID");		


### PR DESCRIPTION
Currently, the XML schema defines an "ID" type just like "string" or "integer" that should be used when declaring an ID attribute within a node in xml... that's right, naming an attribute "ID" is not enough anymore.

The xml parser from previous java versions (earlier than 7u25) was very flexible about this constraint and did not require the ID type on "ID" attributes, but this is not the case with the newest java version. 

With this fix, the isValid() method will traverse the xml document searching for attributes called "ID" and tag them as valid ID xml type, this will avoid an exception during the xmlSignature.validate(ctx) call.

NOTE. This will only happen if the Element.setIdAttribute method exists, which is the method that actually tags an ID attribute as a valid ID xml type. It exists since jdk 1.6 . The method won't be called on jdk 1.5 or previous versions but should not be a problem since the parser of those versions is more flexible.

I tested this fix successfully within jdk_6_u30 and jdk_7_u25
