### PR TITLE
Hack to get around OneLogin not returning an audience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+java-saml.iml

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.onelogin</groupId>
   <artifactId>java-saml</artifactId>
-  <version>1.1</version>
+  <version>1.1.1</version>
   
   <properties>
     <slf4jVersion>1.7.12</slf4jVersion>

--- a/src/main/java/com/onelogin/saml/Response.java
+++ b/src/main/java/com/onelogin/saml/Response.java
@@ -478,8 +478,9 @@ public class Response {
 			if(nodeList.getLength() > 0){
 				Node assertionReferenceNode=nodeList.item(0);
 				String id = assertionReferenceNode.getAttributes().getNamedItem("URI").getNodeValue().substring(1);
-				nameQuery = "/samlp:Response[@ID='"+ id +"']" + assertionXpath;
-			}else{ 
+//				nameQuery = "/samlp:Response[@ID='"+ id +"']" + assertionXpath;
+				nameQuery = "/samlp:Response[@ID='"+ id +"']/saml:Assertion" + assertionXpath;
+			}else{
 				nameQuery = "/samlp:Response/saml:Assertion" + assertionXpath;
 			}
 		}


### PR DESCRIPTION
So, I love your toolkit and is one of the primary reasons why I'm choosing OneLogin over Okta.  Your toolkit is so straightforward and easy to use whereas Okta just suggested using opensaml and I frankly just don't have the time or the patience to deal with that library.

Anyway, funny enough, I used your toolkit with immediate (and very easy) success with Okta.  HOWEVER, when using it with OneLogin the response is never valid because the audience can not be located in the assertion.  As a quick hack to get around it so I could finish my evaluation of both OneLogin and Okta I did the changes included in this pull request.  Perhaps I configured my Test SAML connector wrong in OneLogin - I don't know.  BUT, I have to say, it is hilarious that your toolkit worked out of the box with Okta (I did nothing special) but not with OneLogin...