### PR TITLE
getLocalName causes NPE if xml has \n

### DIFF
--- a/src/main/java/com/onelogin/saml/Response.java
+++ b/src/main/java/com/onelogin/saml/Response.java
@@ -193,7 +193,7 @@ public class Response {
 
 				NodeList subjectConfirmationDataNodes = scn.getChildNodes();			
 				for(int c = 0; c < subjectConfirmationDataNodes.getLength(); c++){				
-					if(subjectConfirmationDataNodes.item(c).getLocalName().equals("SubjectConfirmationData")){
+					if(subjectConfirmationDataNodes.item(c).getLocalName() != null && subjectConfirmationDataNodes.item(c).getLocalName().equals("SubjectConfirmationData")){
 
 						Node recipient = subjectConfirmationDataNodes.item(c).getAttributes().getNamedItem("Recipient");					
 						if(recipient != null && !recipient.getNodeValue().isEmpty() && !recipient.getNodeValue().equals(currentUrl)){


### PR DESCRIPTION
getLocalName causes NullPointerExceptions if the XML is fancy formatted with new lines.  This is because getLocalName() will always return null if the node type is not Element or Attribute.  The libraries treat new lines in SubjectConfirmation as child nodes which causes getLocalName() to be null.