### PR TITLE
Modified AuthRequest NameIdFormat to comply with SAML v2 specification

### DIFF
--- a/src/main/java/com/onelogin/saml/AuthRequest.java
+++ b/src/main/java/com/onelogin/saml/AuthRequest.java
@@ -61,7 +61,7 @@ public class AuthRequest {
 
 		writer.writeStartElement("samlp", "NameIDPolicy", "urn:oasis:names:tc:SAML:2.0:protocol");
 
-		writer.writeAttribute("Format", "urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified");
+		writer.writeAttribute("Format", "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified");
 		writer.writeAttribute("AllowCreate", "true");
 		writer.writeEndElement();
 


### PR DESCRIPTION
According to [SAML V2 Core](http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf) (8.2.1 Unspecified) and [SAML V2 Errata 05](http://docs.oasis-open.org/security/saml/v2.0/errata05/os/saml-v2.0-errata05-os.pdf) (E84: Incorrect NameID Format constant), NameIDFormat in AuthnRequest should be <code>"urn:oasis:names:tc:SAML:<b>1.1</b>:nameid-format:unspecified"</code>