### PR TITLE
Error Message Change + getAttribute() change

### DIFF
--- a/src/main/java/com/onelogin/AccountSettings.java
+++ b/src/main/java/com/onelogin/AccountSettings.java
@@ -31,7 +31,7 @@ public class AccountSettings {
 	 * @param certificate an base64 encoded string.
 	 */
  	public void loadCertificate(String certificate) throws CertificateException {
-		loadCertificate(certificate, false);
+		loadCertificate(certificate, true);
 	}
 	
 	public void loadCertificate(String certificate, boolean isBase64) throws CertificateException {

--- a/src/main/java/com/onelogin/AccountSettings.java
+++ b/src/main/java/com/onelogin/AccountSettings.java
@@ -31,12 +31,19 @@ public class AccountSettings {
 	 * @param certificate an base64 encoded string.
 	 */
  	public void loadCertificate(String certificate) throws CertificateException {
-		CertificateFactory fty = CertificateFactory.getInstance("X.509");
-		ByteArrayInputStream bais = new ByteArrayInputStream(Base64.decodeBase64(certificate.getBytes()));
-		this.idp_cert = fty.generateCertificate(bais);
+		loadCertificate(certificate, false);
 	}
 	
-
+	public void loadCertificate(String certificate, boolean isBase64) throws CertificateException {
+        CertificateFactory fty = CertificateFactory.getInstance("X.509");
+        byte[] cert = certificate.getBytes();
+        if (isBase64) {
+            cert = Base64.decodeBase64(cert);
+        }
+        ByteArrayInputStream bais = new ByteArrayInputStream(cert);
+        this.idp_cert = fty.generateCertificate(bais);
+    }
+    
 	public Certificate getIdpCert() throws CertificateException {
 		if(this.idp_cert == null){
 			loadCertificate(this.certificate);

--- a/src/main/java/com/onelogin/saml/Response.java
+++ b/src/main/java/com/onelogin/saml/Response.java
@@ -138,7 +138,7 @@ public class Response {
 
 			// Validate Assertion timestamps
 			if (!this.validateTimestamps()) {
-				throw new Exception("Timing issues (please check your clock settings)");
+				throw new Exception("Timing issues. Possible reasons include: SAML expired, service's clock setting is not UTC.");
 			}
 
 			// EncryptedAttributes are not supported

--- a/src/main/java/com/onelogin/saml/Response.java
+++ b/src/main/java/com/onelogin/saml/Response.java
@@ -76,7 +76,7 @@ public class Response {
 		this.response = new String(decodedB);
 		this.document = Utils.loadXML(this.response);
 		if(this.document == null){
-			throw new Exception("SAML Response could not be processed");
+			throw new Exception("SAML Response could not be processed, invalid or empty SAML");
 		}
 	}
 
@@ -253,8 +253,10 @@ public class Response {
 
 	public String getAttribute(String name) {
 		HashMap<String, ArrayList<String>> attributes = getAttributes();
+
 		if (!attributes.isEmpty()) {
-			return attributes.get(name).toString();
+			ArrayList<String> attrVal = attributes.get(name);
+            return attrVal == null || attrVal.size() == 0 ? null : attrVal.get(0).toString();
 		}
 		return null;
 	}


### PR DESCRIPTION
Added support for loading certificate that's not base64 encoded, more meaningful error messages, also changed `getAttribute()` 
We should expect `getAttribute("email")` to return the first email (if >1)`example@gmail.com` instead of  `{example@gmail.com}` which is result of `ArrayList<String>::toString()` 