### PR TITLE
Fix #44.Utils.validateXML fails with NullPointerException on Windows

### DIFF
--- a/src/main/java/com/onelogin/saml/Utils.java
+++ b/src/main/java/com/onelogin/saml/Utils.java
@@ -236,7 +236,7 @@ public class Utils {
 			throws Exception {
 
 		try {
-			String schemaFullPath = "schemas" + File.separatorChar + schemaName;
+			String schemaFullPath = "schemas" + "/" + schemaName;
 			log.debug("schemaFullPath: " +schemaFullPath);
 			ClassLoader classLoader = Utils.class.getClassLoader();
 			URL schemaFile = classLoader.getResource(schemaFullPath);


### PR DESCRIPTION
Java is able to process path with "/"