### PR TITLE
#60: allow retrieving the generated request ids

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/Auth.java
+++ b/core/src/main/java/com/onelogin/saml2/Auth.java
@@ -97,14 +97,9 @@ public class Auth {
 	private String errorReason;
 
 	/**
-	 * The id of the last AuthnRequest generated
+	 * The id of the last request (Authn or Logout) generated
 	 */
-	private String lastLoginRequestId;
-
-	/**
-	 * The id of the last LogoutRequest generated
-	 */
-	private String lastLogoutRequestId;
+	private String lastRequestId;
 
 	/**
 	 * Initializes the SP SAML instance.
@@ -242,7 +237,7 @@ public class Auth {
 
 		LOGGER.debug("AuthNRequest sent to " + ssoUrl + " --> " + samlRequest);
 		Util.sendRedirect(response, ssoUrl, parameters);
-		lastLoginRequestId = authnRequest.getId();
+		lastRequestId = authnRequest.getId();
 	}
 
 	/**
@@ -306,7 +301,7 @@ public class Auth {
 		String sloUrl = getSLOurl();
 		LOGGER.debug("Logout request sent to " + sloUrl + " --> " + samlLogoutRequest);
 		Util.sendRedirect(response, sloUrl, parameters);
-		lastLogoutRequestId = logoutRequest.getId();
+		lastRequestId = logoutRequest.getId();
 	}
 
 	/**
@@ -555,19 +550,11 @@ public class Auth {
     }
 
 	/**
-	 * @return the id of the last AuthnRequest generated, null if none
+	 * @return the id of the last request generated (AuthnRequest or LogoutRequest), null if none
 	 */
-	public String getLastLoginRequestId()
+	public String getLastRequestId()
 	{
-		return lastLoginRequestId;
-	}
-
-	/**
-	 * @return the id of the last LogoutRequest generated, null if none
-	 */
-	public String getLastLogoutRequestId()
-	{
-		return lastLogoutRequestId;
+		return lastRequestId;
 	}
 
     /**

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -186,4 +186,12 @@ public class AuthnRequest {
 		template.append("${nameIDPolicyStr}${requestedAuthnContextStr}</samlp:AuthnRequest>");
 		return template;
 	}
+
+	/**
+	 * @return the generated id of the AuthnRequest message
+	 */
+	public String getId()
+	{
+		return id;
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -599,4 +599,12 @@ public class LogoutRequest {
 	public String getError() {
 		return error;
 	}
+
+	/**
+	 * @return the generated id of the LogoutRequest message
+	 */
+	public String getId()
+	{
+		return id;
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -1345,46 +1345,9 @@ public final class Util {
 	 * @return A unique string
 	 */
 	public static String generateUniqueID() {
-		try {
-			Random r = new Random();
-			Integer n = r.nextInt();
-
-			String id = uniqid(n.toString(), true);
-
-			MessageDigest crypt = MessageDigest.getInstance("SHA-1");
-			crypt.reset();
-			crypt.update(id.getBytes());
-			final String uniqueIdSha1 = new BigInteger(1, crypt.digest()).toString(16);
-
-			return UNIQUE_ID_PREFIX + uniqueIdSha1;
-		} catch (Exception e) {
-			throw new RuntimeException("Error executing generateUniqueID: " + e.getMessage(), e);
-		}
+		return UNIQUE_ID_PREFIX + UUID.randomUUID();
 	}
 
-	/**
-	 * Generates random UUID
-	 * 
-	 * @param prefix
-	 *
-	 * @param more_entropy
-	 * 
-	 * @return the random UUID
-	 */
-	public static String uniqid(String prefix, Boolean more_entropy) {
-		if (prefix != null && StringUtils.isEmpty(prefix)) {
-			prefix = StringUtils.EMPTY;
-		}
-
-		if (!more_entropy) {
-			return (String) (prefix + UUID.randomUUID().toString()).substring(
-					0, 13);
-		} else {
-			return (String) (prefix + UUID.randomUUID().toString() + UUID
-					.randomUUID().toString()).substring(0, 23);
-		}
-	}
-	
 	/**
 	 * Interprets a ISO8601 duration value relative to a current time timestamp.
 	 *

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -103,6 +103,7 @@ public final class Util {
 
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(DateTimeZone.UTC);
 	private static final DateTimeFormatter DATE_TIME_FORMAT_MILLS = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(DateTimeZone.UTC);
+	public static final String UNIQUE_ID_PREFIX = "ONELOGIN_";
 
 	/**
 	 * This function load an XML string in a save way. Prevent XEE/XXE Attacks
@@ -1344,9 +1345,6 @@ public final class Util {
 	 * @return A unique string
 	 */
 	public static String generateUniqueID() {
-		String uniqueIdSha1 = StringUtils.EMPTY;
-		String uniqueId = StringUtils.EMPTY;
-
 		try {
 			Random r = new Random();
 			Integer n = r.nextInt();
@@ -1356,14 +1354,13 @@ public final class Util {
 			MessageDigest crypt = MessageDigest.getInstance("SHA-1");
 			crypt.reset();
 			crypt.update(id.getBytes());
-			uniqueIdSha1 = new BigInteger(1, crypt.digest()).toString(16);
+			final String uniqueIdSha1 = new BigInteger(1, crypt.digest()).toString(16);
 
-			uniqueId = "ONELOGIN_" + uniqueIdSha1;
+			return UNIQUE_ID_PREFIX + uniqueIdSha1;
 		} catch (Exception e) {
-			LOGGER.error("Error executing generateUniqueID: " + e.getMessage(), e);
+			throw new RuntimeException("Error executing generateUniqueID: " + e.getMessage(), e);
 		}
-		return uniqueId;
-	}	
+	}
 
 	/**
 	 * Generates random UUID

--- a/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -1,9 +1,11 @@
 package com.onelogin.saml2.test;
 
 
+import static com.onelogin.saml2.util.Util.UNIQUE_ID_PREFIX;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -91,6 +93,8 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("onelogin.saml.properties").build();
 		assertEquals(settings.getIdpEntityId(), auth.getSettings().getIdpEntityId());
 		assertEquals(settings.getSpEntityId(), auth.getSettings().getSpEntityId());
+		assertNull(auth.getLastLoginRequestId());
+		assertNull(auth.getLastLogoutRequestId());
 	}
 
 	/**
@@ -896,6 +900,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		auth.login();
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SSOService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
+		assertThat(auth.getLastLoginRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**
@@ -1011,6 +1016,7 @@ public class AuthTest {
 		auth.logout();
 
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
+		assertThat(auth.getLastLogoutRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -93,8 +93,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("onelogin.saml.properties").build();
 		assertEquals(settings.getIdpEntityId(), auth.getSettings().getIdpEntityId());
 		assertEquals(settings.getSpEntityId(), auth.getSettings().getSpEntityId());
-		assertNull(auth.getLastLoginRequestId());
-		assertNull(auth.getLastLogoutRequestId());
+		assertNull(auth.getLastRequestId());
 	}
 
 	/**
@@ -900,7 +899,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		auth.login();
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SSOService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
-		assertThat(auth.getLastLoginRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
+		assertThat(auth.getLastRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**
@@ -1016,7 +1015,7 @@ public class AuthTest {
 		auth.logout();
 
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
-		assertThat(auth.getLastLogoutRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
+		assertThat(auth.getLastRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -241,6 +241,18 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:X509</saml:AuthnContextClassRef>"));
 	}
 
+	@Test
+	public void testAuthNId() throws Exception
+	{
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+
+		AuthnRequest authnRequest = new AuthnRequest(settings);
+		final String authnRequestStr = Util.base64decodedInflated(authnRequest.getEncodedAuthnRequest());
+
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, containsString("ID=\"" + authnRequest.getId() + "\""));
+	}
+
 	/**
 	 * Tests the AuthnRequest Constructor
 	 * The creation of a deflated SAML Request with and without Destination

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -81,6 +81,7 @@ public class LogoutRequestTest {
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
+		assertThat(logoutRequestStr, containsString("ID=\"" + logoutRequest.getId() + "\""));
 		assertThat(logoutRequestStr, not(containsString("<samlp:SessionIndex>")));
 	}
 

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -1893,7 +1893,7 @@ public class UtilsTest {
 	public void testGenerateUniqueID() {
 		String s1 = Util.generateUniqueID();
 
-		assertThat(s1, containsString("ONELOGIN_"));
+		assertThat(s1, containsString(Util.UNIQUE_ID_PREFIX));
 		assertTrue(s1.length() > 40);
 		
 		String s2 = Util.generateUniqueID();
@@ -1923,10 +1923,10 @@ public class UtilsTest {
 		assertNotEquals(id_2, id_3);
 		assertNotEquals(id_2, id_4);
 
-		String id_5 = Util.uniqid("ONELOGIN_", false);
-		String id_6 = Util.uniqid("ONELOGIN_", true);
-		assertThat(id_5, containsString("ONELOGIN_"));
-		assertThat(id_6, containsString("ONELOGIN_"));
+		String id_5 = Util.uniqid(Util.UNIQUE_ID_PREFIX, false);
+		String id_6 = Util.uniqid(Util.UNIQUE_ID_PREFIX, true);
+		assertThat(id_5, containsString(Util.UNIQUE_ID_PREFIX));
+		assertThat(id_6, containsString(Util.UNIQUE_ID_PREFIX));
 		assertNotEquals(id_5, id_6);
 
 		String id_7 = Util.uniqid("", false);

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1893,7 +1894,7 @@ public class UtilsTest {
 	public void testGenerateUniqueID() {
 		String s1 = Util.generateUniqueID();
 
-		assertThat(s1, containsString(Util.UNIQUE_ID_PREFIX));
+		assertThat(s1, startsWith(Util.UNIQUE_ID_PREFIX));
 		assertTrue(s1.length() > 40);
 		
 		String s2 = Util.generateUniqueID();
@@ -1901,36 +1902,6 @@ public class UtilsTest {
 		assertNotEquals(s1, s2);
 		assertNotEquals(s1, s3);
 		assertNotEquals(s2, s3);
-	}
-
-	/**
-	 * Tests the uniqid method
-	 * 
-	 * @see com.onelogin.saml2.util.Util#uniqid
-	 */
-	@Test
-	public void testUniqid() {
-		String id_1 = Util.uniqid(null, false);
-		String id_2 = Util.uniqid(null, false);
-		assertNotEquals(id_1, id_2);
-
-		String id_3 = Util.uniqid(null, true);
-		String id_4 = Util.uniqid(null, true);
-		assertNotEquals(id_3, id_4);
-
-		assertNotEquals(id_1, id_3);
-		assertNotEquals(id_1, id_4);
-		assertNotEquals(id_2, id_3);
-		assertNotEquals(id_2, id_4);
-
-		String id_5 = Util.uniqid(Util.UNIQUE_ID_PREFIX, false);
-		String id_6 = Util.uniqid(Util.UNIQUE_ID_PREFIX, true);
-		assertThat(id_5, containsString(Util.UNIQUE_ID_PREFIX));
-		assertThat(id_6, containsString(Util.UNIQUE_ID_PREFIX));
-		assertNotEquals(id_5, id_6);
-
-		String id_7 = Util.uniqid("", false);
-		assertNotEquals(id_6, id_7);
 	}
 
 	/**


### PR DESCRIPTION
- Auth now has getLastLoginRequestId/getLastLogoutRequestId methods
  that allow retrieving the id of the generated AuthnRequest/LogoutRequest
  message to be used in response validation