### PR TITLE
Remove power mock agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,3 @@ Make sure maven & your IDE uses this java version.
 
 At the Package Explorer, select the jsp-sample project, 2nd bottom of the mouse and Run As > Run Server
 Select a Tomcat Server in order to deploy the server.
-
-### Unit Tests
-
-The unit tests use PowerMock but do not run with the PowerMock javaagents enabled. This means you will not be able to mock out static methods, but other PowerMock features will work.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,4 @@ Select a Tomcat Server in order to deploy the server.
 
 ### Unit Tests
 
-Known issues while testing:
-
- * [ECLEmma coverage plugin incompatible with PowerMock](http://stackoverflow.com/questions/23363212/powermock-eclemma-coverage-issue)
-  
- * When using @PrepareForTest and PowerMockito the breakpoints not does [not stop when debugging](http://stackoverflow.com/questions/35140575/powermockito-junit-and-eclemma-debugging-dosent-work). The solution is define Rules.
-
- * Java7+ enforces bytecode verification and with Powermock you can experience a [java.lang.VerifyError](http://www.notonlyanecmplace.com/java-7-enforces-bytecode-verification/).
-   At Java8 bytecode verification is mandatory and there is no option to disable it :(
+The unit tests use PowerMock but do not run with the PowerMock javaagents enabled. This means you will not be able to mock out static methods, but other PowerMock features will work.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,18 +30,6 @@
 			<version>1.6.2</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-module-javaagent</artifactId>
-			<version>1.6.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-module-junit4-rule-agent</artifactId>
-			<version>1.6.4</version>
-			<scope>test</scope>
-		</dependency>
 
 		<!-- for log -->
 		<dependency>
@@ -111,7 +99,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.12</version>
 				<configuration>
-					<argLine>-XX:-UseSplitVerifier ${jacoco.agent.argLine}</argLine>
+					<argLine>${jacoco.agent.argLine}</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,15 +19,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.6.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.6.2</version>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/core/src/main/java/com/onelogin/saml2/Auth.java
+++ b/core/src/main/java/com/onelogin/saml2/Auth.java
@@ -8,6 +8,7 @@ import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -440,7 +441,7 @@ public class Auth {
 				logoutResponseBuilder.build(inResponseTo);
 				String samlLogoutResponse = logoutResponseBuilder.getEncodedLogoutResponse();
 
-				Map<String, String> parameters = new HashMap<String, String>();
+				Map<String, String> parameters = new LinkedHashMap<String, String>();
 
 				parameters.put("SAMLResponse", samlLogoutResponse);
 

--- a/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -32,11 +32,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import com.onelogin.saml2.Auth;
-import com.onelogin.saml2.authn.SamlResponse;
 import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.settings.Saml2Settings;
@@ -44,37 +41,7 @@ import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
 
-/*
- * Known issues while testing
- *
- * ECLEmma coverage plugin incompatible with PowerMock
- * http://stackoverflow.com/questions/23363212/powermock-eclemma-coverage-issue
- *
- * import org.junit.runner.RunWith;
- * import org.powermock.modules.junit4.PowerMockRunner;
- * @RunWith(PowerMockRunner.class)
- *
- */
-@PrepareForTest({Auth.class})
 public class AuthTest {
-
-	/*
-	 * When using @PrepareForTest and PowerMockito the breakpoints when debugging
-	 * does not work. Define Rules!
-	 * (http://stackoverflow.com/questions/35140575/powermockito-junit-and-eclemma-debugging-dosent-work)
-	 *
-	 * https://github.com/jayway/powermock/wiki/PowerMockRule
-	 *
-	 * import org.junit.Rule;
-	 * import org.powermock.modules.junit4.rule.PowerMockRule;
-	 * @Rule
-	 * public PowerMockRule rule = new PowerMockRule();
-	 *
-	 */
-
-	//import org.powermock.modules.junit4.rule.PowerMockRule;
-	//@Rule
-	//public PowerMockRule rule = new PowerMockRule();
 
 	/**
 	 * Tests the constructor of Auth

--- a/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -46,32 +46,32 @@ import com.onelogin.saml2.util.Util;
 
 /*
  * Known issues while testing
- * 
+ *
  * ECLEmma coverage plugin incompatible with PowerMock
  * http://stackoverflow.com/questions/23363212/powermock-eclemma-coverage-issue
  *
  * import org.junit.runner.RunWith;
- * import org.powermock.modules.junit4.PowerMockRunner; 
+ * import org.powermock.modules.junit4.PowerMockRunner;
  * @RunWith(PowerMockRunner.class)
- * 
+ *
  */
 @PrepareForTest({Auth.class})
 public class AuthTest {
 
 	/*
-	 * When using @PrepareForTest and PowerMockito the breakpoints when debugging 
+	 * When using @PrepareForTest and PowerMockito the breakpoints when debugging
 	 * does not work. Define Rules!
 	 * (http://stackoverflow.com/questions/35140575/powermockito-junit-and-eclemma-debugging-dosent-work)
-	 * 
+	 *
 	 * https://github.com/jayway/powermock/wiki/PowerMockRule
-	 * 
+	 *
 	 * import org.junit.Rule;
 	 * import org.powermock.modules.junit4.rule.PowerMockRule;
 	 * @Rule
 	 * public PowerMockRule rule = new PowerMockRule();
-	 * 
+	 *
 	 */
-	
+
 	//import org.powermock.modules.junit4.rule.PowerMockRule;
 	//@Rule
 	//public PowerMockRule rule = new PowerMockRule();
@@ -527,7 +527,7 @@ public class AuthTest {
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();
-		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLResponse=(.)*&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha512&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp&Signature=(.)*"));
+		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLResponse=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha512&Signature=(.)*"));
 		verify(session, times(1)).invalidate();
 		assertTrue(auth.getErrors().isEmpty());
 	}

--- a/core/src/test/java/com/onelogin/saml2/test/MetadataTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/MetadataTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.security.cert.CertificateEncodingException;
 import java.util.Calendar;
 
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.w3c.dom.Document;
 import org.junit.Test;
 
@@ -25,7 +24,6 @@ import com.onelogin.saml2.util.Util;
 /**
  * Tests the com.onelogin.saml2.Metadata class
  */
-@PrepareForTest({Metadata.class})
 public class MetadataTest {
 	/**
 	 * Tests the constructor method of Metadata

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -4,14 +4,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
 
 import com.onelogin.saml2.authn.AuthnRequest;
 import com.onelogin.saml2.settings.Saml2Settings;
@@ -31,11 +28,13 @@ public class AuthnRequestTest {
 	public void testGetEncodedAuthnRequestSimulated() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
-		String authnRequestString = Util.getFileAsString("data/requests/authn_request.xml");
-		AuthnRequest authnRequest = PowerMockito.spy(new AuthnRequest(settings));
-
-		when(authnRequest, method(AuthnRequest.class, "getAuthnRequestXml")).withNoArguments().thenReturn(
-				authnRequestString);
+		final String authnRequestString = Util.getFileAsString("data/requests/authn_request.xml");
+		AuthnRequest authnRequest = new AuthnRequest(settings) {
+			@Override
+			protected String getAuthnRequestXml() {
+				return authnRequestString;
+			}
+		};
 
 		String expectedAuthnRequestStringBase64 = Util.getFileAsString("data/requests/authn_request.xml.deflated.base64");
 		String authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -4,37 +4,21 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-//import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import com.onelogin.saml2.authn.AuthnRequest;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Util;
 
-@PrepareForTest({AuthnRequest.class})
 public class AuthnRequestTest {
-
-	 @Rule
-	 public PowerMockRule rule = new PowerMockRule();
 
 	/**
 	 * Tests the getEncodedAuthnRequest method of AuthnRequest

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -18,8 +18,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -31,12 +29,8 @@ import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Util;
 import com.onelogin.saml2.util.Constants;
 
-@PrepareForTest({SamlResponse.class})
 public class AuthnResponseTest {
-	
-	@Rule
-	public PowerMockRule rule = new PowerMockRule();
-	
+
 	/**
 	 * Tests the constructor of SamlResponse
 	 *

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -21,13 +21,11 @@ import javax.xml.xpath.XPathExpressionException;
 
 import java.security.PrivateKey;
 
+import org.powermock.api.mockito.PowerMockito;
 import org.w3c.dom.Document;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.logout.LogoutRequest;
@@ -35,11 +33,7 @@ import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Util;
 
-@PrepareForTest({LogoutRequest.class})
 public class LogoutRequestTest {
-
-	@Rule
-	public PowerMockRule rule = new PowerMockRule();
 
 	/**
 	 * Tests the constructor and the getEncodedLogoutRequest method of LogoutRequest

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,10 +20,8 @@ import javax.xml.xpath.XPathExpressionException;
 
 import java.security.PrivateKey;
 
-import org.powermock.api.mockito.PowerMockito;
 import org.w3c.dom.Document;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.onelogin.saml2.exception.XMLEntityException;
@@ -46,10 +43,13 @@ public class LogoutRequestTest {
 	public void testGetEncodedLogoutRequestSimulated() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
-		String logoutRequestString = Util.getFileAsString("data/logout_requests/logout_request.xml");
-		LogoutRequest logoutRequest = PowerMockito.spy(new LogoutRequest(settings));
- 		PowerMockito.when(logoutRequest, method(LogoutRequest.class, "getLogoutRequestXml")).withNoArguments().thenReturn(
-				logoutRequestString);
+		final String logoutRequestString = Util.getFileAsString("data/logout_requests/logout_request.xml");
+		LogoutRequest logoutRequest = new LogoutRequest(settings) {
+			@Override
+			protected String getLogoutRequestXml() {
+				return logoutRequestString;
+			}
+		};
 
 		String expectedLogoutRequestStringBase64 = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -18,7 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.junit.Test;
-import org.powermock.api.mockito.PowerMockito;
 
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.logout.LogoutResponse;
@@ -40,14 +38,17 @@ public class LogoutResponseTest {
 	public void testGetEncodedLogoutResponseSimulated() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
-		String logoutResponseString = Util.getFileAsString("data/logout_responses/logout_response.xml");
+		final String logoutResponseString = Util.getFileAsString("data/logout_responses/logout_response.xml");
 
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer( "/"));
 
-		LogoutResponse logoutResponseBuilder = PowerMockito.spy(new LogoutResponse(settings, request));
- 		PowerMockito.when(logoutResponseBuilder, method(LogoutResponse.class, "getLogoutResponseXml")).withNoArguments().thenReturn(
- 				logoutResponseString);
+		LogoutResponse logoutResponseBuilder = new LogoutResponse(settings, request) {
+			@Override
+			protected String getLogoutResponseXml() {
+				return logoutResponseString;
+			}
+		};
 
  		logoutResponseBuilder.build();
 
@@ -56,9 +57,12 @@ public class LogoutResponseTest {
 
 		assertEquals(logoutResponseStringBase64, expectedLogoutResponseStringBase64);
 
-		LogoutResponse logoutResponse = PowerMockito.spy(new LogoutResponse(settings, request));
- 		PowerMockito.when(logoutResponse, method(LogoutResponse.class, "getLogoutResponseXml")).withNoArguments().thenReturn(
- 				logoutResponseString);
+		LogoutResponse logoutResponse = new LogoutResponse(settings, request) {
+			@Override
+			protected String getLogoutResponseXml() {
+				return logoutResponseString;
+			}
+		};
  		logoutResponseStringBase64 = logoutResponse.getEncodedLogoutResponse();
  		assertEquals(logoutResponseStringBase64, expectedLogoutResponseStringBase64);
 	}

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -17,11 +17,8 @@ import java.net.URISyntaxException;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.logout.LogoutResponse;
@@ -30,11 +27,7 @@ import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Util;
 import com.onelogin.saml2.util.Constants;
 
-@PrepareForTest({LogoutResponse.class})
 public class LogoutResponseTest {
-
-	@Rule
-	public PowerMockRule rule = new PowerMockRule();
 
 	/**
 	 * Tests the constructor, the build and the getEncodedLogoutResponse method of LogoutResponse

--- a/core/src/test/java/com/onelogin/saml2/test/model/ContactTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/model/ContactTest.java
@@ -1,7 +1,6 @@
 package com.onelogin.saml2.test.model;
 
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import static org.junit.Assert.assertEquals;
 
@@ -10,7 +9,6 @@ import com.onelogin.saml2.model.Contact;
 /**
  * Tests the com.onelogin.saml2.model.Contact class
  */
-@PrepareForTest({Contact.class})
 public class ContactTest {
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/model/OrganizationTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/model/OrganizationTest.java
@@ -4,7 +4,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -15,7 +14,6 @@ import com.onelogin.saml2.model.Organization;
 /**
  * Tests the com.onelogin.saml2.model.Organization class
  */
-@PrepareForTest({Organization.class})
 public class OrganizationTest {
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/model/SamlResponseStatusTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/model/SamlResponseStatusTest.java
@@ -1,7 +1,6 @@
 package com.onelogin.saml2.test.model;
 
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -13,7 +12,6 @@ import com.onelogin.saml2.model.SamlResponseStatus;
 /**
  * Tests the com.onelogin.saml2.model.SamlResponseStatus class
  */
-@PrepareForTest({SamlResponseStatus.class})
 public class SamlResponseStatusTest {
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
@@ -13,7 +13,6 @@ import java.util.Calendar;
 import java.util.List;
 
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.w3c.dom.Document;
 
 import com.onelogin.saml2.Metadata;
@@ -25,7 +24,6 @@ import com.onelogin.saml2.util.Util;
 /**
  * Tests the com.onelogin.saml2.settings.Saml2Settings class
  */
-@PrepareForTest({Saml2Settings.class})
 public class Saml2SettingsTest {
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.model.Contact;
@@ -27,7 +26,6 @@ import com.onelogin.saml2.util.Util;
 /**
  * Tests the com.onelogin.saml2.settings.SettingsBuilder class
  */
-@PrepareForTest({SettingsBuilder.class})
 public class SettingBuilderTest {
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -46,7 +46,6 @@ import org.apache.xml.security.exceptions.XMLSecurityException;
 import org.apache.xml.security.signature.XMLSignatureException;
 import org.joda.time.DateTime;
 import org.junit.Test;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -61,7 +60,6 @@ import com.onelogin.saml2.util.Util;
 /**
  * Tests the com.onelogin.saml2.util.Util class
  */
-@PrepareForTest({Util.class})
 public class UtilsTest {
 
 	/**


### PR DESCRIPTION
Removed the PowerMock javaagents as this is what causes problems with the bytecode verifier. Tests now pass in JDK8.