### PR TITLE
#62: check InResponseTo in Response more strictly

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.onelogin.saml2.authn.SamlResponse;
+import com.onelogin.saml2.logout.LogoutResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -70,6 +72,7 @@ public class Saml2Settings {
 	private String requestedAuthnContextComparison = "exact";
 	private Boolean wantXMLValidation = true;
 	private String signatureAlgorithm = Constants.RSA_SHA1;
+	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
 
 	// Misc
 	private List<Contact> contacts = new LinkedList<Contact>();
@@ -632,6 +635,28 @@ public class Saml2Settings {
 	 */
 	public void setSignatureAlgorithm(String signatureAlgorithm) {
 		this.signatureAlgorithm = signatureAlgorithm;
+	}
+
+	/**
+	 * Controls if unsolicited Responses are rejected if they contain an InResponseTo value.
+	 *
+	 * If false using a validate method {@link SamlResponse#isValid(String)} with a null argument will
+	 * accept messages with any (or none) InResponseTo value.
+	 *
+	 * If true using these methods with a null argument will only accept messages with no InRespoonseTo value,
+	 * and reject messages where the value is set.
+	 *
+	 * In all cases using validate with a specified request ID will only accept responses that have the same
+	 * InResponseTo id set.
+	 *
+	 * @param rejectUnsolicitedResponsesWithInResponseTo whether to strictly check the InResponseTo attribute
+	 */
+	public void setRejectUnsolicitedResponsesWithInResponseTo(boolean rejectUnsolicitedResponsesWithInResponseTo) {
+		this.rejectUnsolicitedResponsesWithInResponseTo = rejectUnsolicitedResponsesWithInResponseTo;
+	}
+
+	public boolean isRejectUnsolicitedResponsesWithInResponseTo() {
+		return rejectUnsolicitedResponsesWithInResponseTo;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -82,6 +82,7 @@ public class SettingsBuilder {
 	public final static String SECURITY_REQUESTED_AUTHNCONTEXTCOMPARISON = "onelogin.saml2.security.requested_authncontextcomparison";
 	public final static String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
 	public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
+	public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO = "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
 
 	// Misc
 	public final static String CONTACT_TECHNICAL_GIVEN_NAME = "onelogin.saml2.contacts.technical.given_name";
@@ -268,6 +269,11 @@ public class SettingsBuilder {
 		String signatureAlgorithm = loadStringProperty(SECURITY_SIGNATURE_ALGORITHM);
 		if (signatureAlgorithm != null && !signatureAlgorithm.isEmpty())
 			saml2Setting.setSignatureAlgorithm(signatureAlgorithm);
+
+		Boolean rejectUnsolicitedResponsesWithInResponseTo = loadBooleanProperty(SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO);
+		if (rejectUnsolicitedResponsesWithInResponseTo != null) {
+			saml2Setting.setRejectUnsolicitedResponsesWithInResponseTo(rejectUnsolicitedResponsesWithInResponseTo);
+		}
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -1066,7 +1066,7 @@ public class AuthnResponseTest {
 		final String samlResponseEncoded = loadSignMessageAndEncode("data/responses/invalids/invalid_unpaired_inresponsesto.xml");
 
 		assertResponseValid(settings, samlResponseEncoded, true, false,
-				"A valid SubjectConfirmation was not found on this Response - SubjectConfirmationData has an invalid InResponseTo value");
+				"A valid SubjectConfirmation was not found on this Response: SubjectConfirmationData has an invalid InResponseTo value");
 		assertResponseValid(settings, samlResponseEncoded, false, true, null);
 	}
 

--- a/core/src/test/resources/data/responses/invalids/invalid_subjectconfirmation_multiple_issues.xml
+++ b/core/src/test/resources/data/responses/invalids/invalid_subjectconfirmation_multiple_issues.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfxc32aed67-820f-4296-0c20-205a10dd5787" Version="2.0" IssueInstant="2011-06-17T14:54:14Z" Destination="http://localhost:8080/java-saml-jspsample/acs.jsp" InResponseTo="_57bcbf70-7b1f-012e-c821-782bcb13bb38">
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfxc32aed67-820f-4296-0c20-205a10dd5787" Version="2.0" IssueInstant="2011-06-17T14:54:14Z" Destination="http://localhost:8080/java-saml-jspsample/acs.jsp">
     <saml:Issuer>https://pitbulk.no-ip.org/simplesaml/saml2/idp/metadata.php</saml:Issuer>
     <samlp:Status>
         <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>

--- a/core/src/test/resources/data/responses/invalids/invalid_unpaired_inresponsesto.xml
+++ b/core/src/test/resources/data/responses/invalids/invalid_unpaired_inresponsesto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfxc32aed67-820f-4296-0c20-205a10dd5787" Version="2.0" IssueInstant="2011-06-17T14:54:14Z" Destination="http://localhost:8080/java-saml-jspsample/acs.jsp">
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfxc32aed67-820f-4296-0c20-205a10dd5787" Version="2.0" IssueInstant="2011-06-17T14:54:14Z" InResponseTo="unpaired" Destination="http://localhost:8080/java-saml-jspsample/acs.jsp">
     <saml:Issuer>https://pitbulk.no-ip.org/simplesaml/saml2/idp/metadata.php</saml:Issuer>
     <samlp:Status>
         <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
@@ -9,15 +9,15 @@
         <saml:Subject>
             <saml:NameID SPNameQualifier="hello.com" Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">someone@example.com</saml:NameID>
             <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-                <saml:SubjectConfirmationData Recipient="http://localhost:8080/java-saml-jspsample/acs.jsp"/>
+                <saml:SubjectConfirmationData NotOnOrAfter="2020-06-17T14:59:14Z" Recipient="http://localhost:8080/java-saml-jspsample/acs.jsp"/>
             </saml:SubjectConfirmation>
         </saml:Subject>
-        <saml:Conditions NotBefore="2010-06-17T14:53:44Z" NotOnOrAfter="2121-06-17T14:59:14Z">
+        <saml:Conditions NotBefore="2010-06-17T14:53:44Z" NotOnOrAfter="2021-06-17T14:59:14Z">
             <saml:AudienceRestriction>
                 <saml:Audience>http://localhost:8080/java-saml-jspsample/metadata.jsp</saml:Audience>
             </saml:AudienceRestriction>
         </saml:Conditions>
-        <saml:AuthnStatement AuthnInstant="2011-06-17T14:54:07Z" SessionNotOnOrAfter="2121-06-17T22:54:14Z" SessionIndex="_51be37965feb5579d803141076936dc2e9d1d98ebf">
+        <saml:AuthnStatement AuthnInstant="2011-06-17T14:54:07Z" SessionNotOnOrAfter="2021-06-17T22:54:14Z" SessionIndex="_51be37965feb5579d803141076936dc2e9d1d98ebf">
             <saml:AuthnContext>
                 <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
             </saml:AuthnContext>

--- a/core/src/test/resources/data/responses/valid_idp_initiated_response.xml
+++ b/core/src/test/resources/data/responses/valid_idp_initiated_response.xml
@@ -9,15 +9,15 @@
         <saml:Subject>
             <saml:NameID SPNameQualifier="hello.com" Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">someone@example.com</saml:NameID>
             <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-                <saml:SubjectConfirmationData Recipient="http://localhost:8080/java-saml-jspsample/acs.jsp"/>
+                <saml:SubjectConfirmationData NotOnOrAfter="2020-06-17T14:59:14Z" Recipient="http://localhost:8080/java-saml-jspsample/acs.jsp"/>
             </saml:SubjectConfirmation>
         </saml:Subject>
-        <saml:Conditions NotBefore="2010-06-17T14:53:44Z" NotOnOrAfter="2121-06-17T14:59:14Z">
+        <saml:Conditions NotBefore="2010-06-17T14:53:44Z" NotOnOrAfter="2021-06-17T14:59:14Z">
             <saml:AudienceRestriction>
                 <saml:Audience>http://localhost:8080/java-saml-jspsample/metadata.jsp</saml:Audience>
             </saml:AudienceRestriction>
         </saml:Conditions>
-        <saml:AuthnStatement AuthnInstant="2011-06-17T14:54:07Z" SessionNotOnOrAfter="2121-06-17T22:54:14Z" SessionIndex="_51be37965feb5579d803141076936dc2e9d1d98ebf">
+        <saml:AuthnStatement AuthnInstant="2011-06-17T14:54:07Z" SessionNotOnOrAfter="2021-06-17T22:54:14Z" SessionIndex="_51be37965feb5579d803141076936dc2e9d1d98ebf">
             <saml:AuthnContext>
                 <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
             </saml:AuthnContext>


### PR DESCRIPTION
This fixes a few cases where the InResponseTo attribute wasn't checked correctly:

* reject Responses with no InResponseTo if one was provided as an argument to validate
 * i.e. if you call `validate('id')`, and the Response had no `InResponseTo` this was previously allowed, now is denied
* reject Responses with a InResponseTo if null was provided as an argument to validate
 * this is disabled by default, enabled by `Saml2Settings.rejectUnsolicitedResponsesWithInResponseTo`
 * i.e. if you call `validate(null)` and the Response had a `InResponseTo` this was previously always allowed, now will only be allowed when `rejectUnsolicitedResponsesWithInResponseTo` is `false` (which is the default) 
* reject SubjectConfirmationData without a InResponseTo, when the Response has one
 * i.e. if the Response had a `InResponseTo` a SubjectConfirmationData without the InResponseTo was considered valid, now it is not