### PR TITLE
set scope=provided for javax.servlet:servlet-api

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,7 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- date and time library for Java -->


### PR DESCRIPTION
Use provided scope for the servlet-api dependency as this is expected to be provided by the servlet container.

https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope