### PR TITLE
fixes #78: make sure the correct Signature elements are  verified

### DIFF
--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -1449,39 +1449,44 @@ public class AuthnResponseTest {
 	 * @see com.onelogin.saml2.authn.SamlResponse#isValid
 	 */
 	@Test
-	public void testIsValidEnc() throws Exception {
+	public void testIsValid_doubleSignedEncrypted() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
-		settings.setWantAssertionsSigned(false);
-		settings.setWantMessagesSigned(false);
+		settings.setWantAssertionsSigned(true);
+		settings.setWantMessagesSigned(true);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/double_signed_encrypted_assertion.xml.base64");
 
-		settings.setStrict(false);
-		SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
-		assertTrue(samlResponse.isValid());
+		assertResponseValid(settings, samlResponseEncoded, false, true, null);
+		assertResponseValid(settings, samlResponseEncoded, true, true, null);
+	}
 
-		settings.setStrict(true);
-		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
-		assertTrue(samlResponse.isValid());
+	@Test
+	public void testIsValid_signedResponseEncryptedAssertion() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+		settings.setWantAssertionsSigned(false);
+		settings.setWantMessagesSigned(true);
 
-		samlResponseEncoded = Util.getFileAsString("data/responses/signed_message_encrypted_assertion.xml.base64");
+		String samlResponseEncoded = Util.getFileAsString("data/responses/signed_message_encrypted_assertion.xml.base64");
 
-		settings.setStrict(false);
-		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
-		assertTrue(samlResponse.isValid());
+		assertResponseValid(settings, samlResponseEncoded, false, true, null);
+		assertResponseValid(settings, samlResponseEncoded, true, true, null);
+		settings.setWantAssertionsSigned(true);
+		assertResponseValid(settings, samlResponseEncoded, false, true, null);
+		assertResponseValid(settings, samlResponseEncoded, true, false, "The Assertion of the Response is not signed and the SP requires it");
+	}
 
-		settings.setStrict(true);
-		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
-		assertTrue(samlResponse.isValid());
+	@Test
+	public void testIsValid_signedEncryptedAssertion() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+		settings.setWantAssertionsSigned(true);
+		settings.setWantMessagesSigned(false);
 
-		samlResponseEncoded = Util.getFileAsString("data/responses/signed_encrypted_assertion.xml.base64");
+		String samlResponseEncoded = Util.getFileAsString("data/responses/signed_encrypted_assertion.xml.base64");
 
-		settings.setStrict(false);
-		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
-		assertTrue(samlResponse.isValid());
-
-		settings.setStrict(true);
-		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
-		assertTrue(samlResponse.isValid());
+		assertResponseValid(settings, samlResponseEncoded, false, true, null);
+		assertResponseValid(settings, samlResponseEncoded, true, true, null);
+		settings.setWantMessagesSigned(true);
+		assertResponseValid(settings, samlResponseEncoded, false, true, null);
+		assertResponseValid(settings, samlResponseEncoded, true, false, "The Message of the Response is not signed and the SP requires it");
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -609,6 +609,23 @@ public class AuthnResponseTest {
 		assertEquals("someone@example.org", samlResponse.getNameId());
 	}
 
+	@Test
+	public void testValidatesTheExpectedSignatures() throws Exception {
+		// having
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+		settings.setWantAssertionsSigned(true);
+		settings.setWantMessagesSigned(true);
+
+		String samlResponseEncoded = Util.base64encoder(Util.getFileAsString("data/responses/invalids/attacks/response_with_spoofed_response_signature.xml"));
+
+		// when
+		SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+
+		// then
+		assertFalse(samlResponse.isValid());
+		assertEquals("Unexpected number of Response signatures found. SAML Response rejected.", samlResponse.getError());
+	}
+
 	/**
 	 * Tests the getSessionNotOnOrAfter method of SamlResponse
 	 *
@@ -851,6 +868,7 @@ public class AuthnResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		String samlResponseEncoded = Util.getFileAsString("data/responses/invalids/response_encrypted_subconfirm_as_nameid.xml.base64");
 		settings.setStrict(false);
+		settings.setWantAssertionsSigned(false);
 		SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertTrue(samlResponse.isValid());
 		String nameId = samlResponse.getNameId();
@@ -1630,17 +1648,17 @@ public class AuthnResponseTest {
 		samlResponseEncoded = Util.getFileAsString("data/responses/invalids/triple_signed_response.xml.base64");
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertFalse(samlResponse.isValid());
-		assertEquals("Duplicated ID. SAML Response rejected", samlResponse.getError());
+		assertEquals("Unexpected number of Response signatures found. SAML Response rejected.", samlResponse.getError());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/invalids/signed_assertion_response_with_2signatures.xml.base64");
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertFalse(samlResponse.isValid());
-		assertEquals("Duplicated ID. SAML Response rejected", samlResponse.getError());
+		assertEquals("Unexpected number of Response signatures found. SAML Response rejected.", samlResponse.getError());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/invalids/signed_message_response_with_2signatures.xml.base64");
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertFalse(samlResponse.isValid());
-		assertEquals("Duplicated ID. SAML Response rejected", samlResponse.getError());
+		assertEquals("Unexpected number of Response signatures found. SAML Response rejected.", samlResponse.getError());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/invalids/wrong_signed_element.xml.base64");
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -925,34 +925,34 @@ public class UtilsTest {
 		String fingerprint_c2_sha1 = "c51985d947f1be57082025050846eb27f6cab783";
 
 		// No doc
-		assertFalse(Util.validateSign(null, cert, null, "SHA-1"));
-		assertFalse(Util.validateSign(null, cert, null, null));
+		assertFalse(Util.validateSign(null, cert, null, "SHA-1", true, false));
+		assertFalse(Util.validateSign(null, cert, null, null, true, false));
 
 		// No cert & no fingerprint
-		assertFalse(Util.validateSign(samlResponseDocument, null, null, "SHA-1"));
-		assertFalse(Util.validateSign(samlResponseDocument, null, null, null));
+		assertFalse(Util.validateSign(samlResponseDocument, null, null, "SHA-1", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, null, null, true, false));
 
 		// Wrong cert
-		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, "SHA-1"));
-		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, null));
+		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, "SHA-1", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, null, true, false));
 
 		// Wrong fingerprint
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1"));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, true, false));
 
 		// Wrong fingerprint alg
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-1"));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, null));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha1, "SHA-256"));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-1", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, null, true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha1, "SHA-256", true, false));
 
 		// Reference validation failed
 		NamedNodeMap attrs = samlResponseDocument.getFirstChild().getAttributes();
 		Node nodeAttr = attrs.getNamedItem("ID");		
 		nodeAttr.setTextContent("pfxc3d2b542-0f7e-8767-8e87-5b0dc6913375-alter");
-		assertFalse(Util.validateSign(samlResponseDocument, cert, null, null));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1"));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-256"));
+		assertFalse(Util.validateSign(samlResponseDocument, cert, null, null, true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-256", true, false));
 
 		// Element changed
 		String signedAssertionStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
@@ -960,10 +960,10 @@ public class UtilsTest {
 		Document samlSignedAssertionDocument = Util.loadXML(samlSignedAssertionStr);
 		Node audience = samlSignedAssertionDocument.getElementsByTagName("saml:Audience").item(0);
 		audience.setTextContent("http://sp.example.com/metadata.php");
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, cert, null, null));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, "SHA-1"));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, null));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c1_sha256, "SHA-256"));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, cert, null, null, false, true));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, "SHA-1", false, true));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, null, false, true));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c1_sha256, "SHA-256", false, true));
 
 		// Manipulated Node fails
 		String doubleSignedResponseStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
@@ -976,28 +976,28 @@ public class UtilsTest {
 		String noSignatureStr = Util.getFileAsString("data/responses/invalids/no_signature.xml.base64");
 		String samlNoSignatureStr = new String(Util.base64decoder(noSignatureStr));
 		Document samlNoSignatureDocument = Util.loadXML(samlNoSignatureStr);
-		assertFalse(Util.validateSign(samlNoSignatureDocument, cert, null, null));
-		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, "SHA-1"));
-		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, null));
-		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c1_sha256, "SHA-256"));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, cert, null, null, true, false));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, "SHA-1", false, true));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, null, true, true));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c1_sha256, "SHA-256", false, true));
 		
 		// No key
 		String noKeyStr = Util.getFileAsString("data/responses/invalids/no_key.xml.base64");
 		String samlNoKeyStr = new String(Util.base64decoder(noKeyStr));
 		Document samlNoKeyDocument = Util.loadXML(samlNoKeyStr);
-		assertFalse(Util.validateSign(samlNoKeyDocument, cert, null, null));
-		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, "SHA-1"));
-		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, null));
-		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c1_sha256, "SHA-256"));
+		assertFalse(Util.validateSign(samlNoKeyDocument, cert, null, null, false, true));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, "SHA-1", false, true));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, null, false, true));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c1_sha256, "SHA-256", false, true));
 
 		// Signature Wrapping Attack
 		String sigAttackStr = Util.getFileAsString("data/responses/invalids/signature_wrapping_attack.xml.base64");
 		String samlSigAttackStr = new String(Util.base64decoder(sigAttackStr));
 		Document samlSigAttackDocument = Util.loadXML(samlSigAttackStr);
-		assertFalse(Util.validateSign(samlSigAttackDocument, cert, null, null));
-		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, "SHA-1"));
-		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, null));
-		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c1_sha256, "SHA-256"));		
+		assertFalse(Util.validateSign(samlSigAttackDocument, cert, null, null, true, false));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, "SHA-1", true, false));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, null, true, false));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c1_sha256, "SHA-256", true, false));
 	}
 
 	/**
@@ -1022,30 +1022,35 @@ public class UtilsTest {
 		String samlSignedResponseStr = new String(Util.base64decoder(signedResponseStr));
 		Document samlSignedResponseDocument = Util.loadXML(samlSignedResponseStr);
 
-		assertTrue(Util.validateSign(samlSignedResponseDocument, cert, null, null));
-		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, null));
-		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, "SHA-1"));
-		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256"));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, cert, null, null, true, false));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, null, true, false));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, "SHA-1", true, false));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256", true, false));
+		assertFalse(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256", false, true));
 
 		// Signed Assertion Response
 		String signedAssertionStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
 		String samlSignedAssertionStr = new String(Util.base64decoder(signedAssertionStr));
 		Document samlSignedAssertionDocument = Util.loadXML(samlSignedAssertionStr);
 		
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, cert, null, null));
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, null));
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, "SHA-1"));
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha256, "SHA-256"));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, cert, null, null, false, true));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, null, false, true));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, "SHA-1", false, true));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha256, "SHA-256", false, true));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha256, "SHA-256", true, false));
 
 		// Double Signed Response
-		String doubleSignedResponseStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
+		String doubleSignedResponseStr = Util.getFileAsString("data/responses/double_signed_response.xml.base64");
 		String samlDoubleSignedResponseStr = new String(Util.base64decoder(doubleSignedResponseStr));
 		Document samlDoubleSignedResponseDocument = Util.loadXML(samlDoubleSignedResponseStr);
 
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, cert, null, null));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, null));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, "SHA-1"));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256"));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, cert, null, null, true, true));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, null, true, true));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, "SHA-1", true, true));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", true, true));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", true, false));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", false, true));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", false, false));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -1,5 +1,7 @@
 package com.onelogin.saml2.test.util;
 
+import static com.onelogin.saml2.util.Util.ASSERTION_SIGNATURE_XPATH;
+import static com.onelogin.saml2.util.Util.RESPONSE_SIGNATURE_XPATH;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
@@ -925,34 +927,50 @@ public class UtilsTest {
 		String fingerprint_c2_sha1 = "c51985d947f1be57082025050846eb27f6cab783";
 
 		// No doc
-		assertFalse(Util.validateSign(null, cert, null, "SHA-1", true, false));
-		assertFalse(Util.validateSign(null, cert, null, null, true, false));
+		assertFalse(Util.validateSign(null, cert, null, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(null, cert, null, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(null, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(null, cert, null, null, ASSERTION_SIGNATURE_XPATH));
 
 		// No cert & no fingerprint
-		assertFalse(Util.validateSign(samlResponseDocument, null, null, "SHA-1", true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, null, null, true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, null, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, null, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, null, null, ASSERTION_SIGNATURE_XPATH));
 
 		// Wrong cert
-		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, "SHA-1", true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, null, true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, cert_2, null, "SHA-1", ASSERTION_SIGNATURE_XPATH));
 
 		// Wrong fingerprint
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
 
 		// Wrong fingerprint alg
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-1", true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, null, true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha1, "SHA-256", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha1, "SHA-256", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha1, "SHA-256", ASSERTION_SIGNATURE_XPATH));
 
 		// Reference validation failed
 		NamedNodeMap attrs = samlResponseDocument.getFirstChild().getAttributes();
 		Node nodeAttr = attrs.getNamedItem("ID");		
 		nodeAttr.setTextContent("pfxc3d2b542-0f7e-8767-8e87-5b0dc6913375-alter");
-		assertFalse(Util.validateSign(samlResponseDocument, cert, null, null, true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, true, false));
-		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-256", true, false));
+		assertFalse(Util.validateSign(samlResponseDocument, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-256", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlResponseDocument, null, fingerprint_c1_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
+
 
 		// Element changed
 		String signedAssertionStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
@@ -960,10 +978,15 @@ public class UtilsTest {
 		Document samlSignedAssertionDocument = Util.loadXML(samlSignedAssertionStr);
 		Node audience = samlSignedAssertionDocument.getElementsByTagName("saml:Audience").item(0);
 		audience.setTextContent("http://sp.example.com/metadata.php");
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, cert, null, null, false, true));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, "SHA-1", false, true));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, null, false, true));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c1_sha256, "SHA-256", false, true));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c1_sha256, "SHA-256", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_c1_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
+
 
 		// Manipulated Node fails
 		String doubleSignedResponseStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
@@ -976,28 +999,42 @@ public class UtilsTest {
 		String noSignatureStr = Util.getFileAsString("data/responses/invalids/no_signature.xml.base64");
 		String samlNoSignatureStr = new String(Util.base64decoder(noSignatureStr));
 		Document samlNoSignatureDocument = Util.loadXML(samlNoSignatureStr);
-		assertFalse(Util.validateSign(samlNoSignatureDocument, cert, null, null, true, false));
-		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, "SHA-1", false, true));
-		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, null, true, true));
-		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c1_sha256, "SHA-256", false, true));
-		
+		assertFalse(Util.validateSign(samlNoSignatureDocument, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c1_sha256, "SHA-256", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoSignatureDocument, null, fingerprint_c1_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
+
+
 		// No key
 		String noKeyStr = Util.getFileAsString("data/responses/invalids/no_key.xml.base64");
 		String samlNoKeyStr = new String(Util.base64decoder(noKeyStr));
 		Document samlNoKeyDocument = Util.loadXML(samlNoKeyStr);
-		assertFalse(Util.validateSign(samlNoKeyDocument, cert, null, null, false, true));
-		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, "SHA-1", false, true));
-		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, null, false, true));
-		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c1_sha256, "SHA-256", false, true));
+		assertFalse(Util.validateSign(samlNoKeyDocument, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c1_sha256, "SHA-256", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlNoKeyDocument, null, fingerprint_c1_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
+
 
 		// Signature Wrapping Attack
 		String sigAttackStr = Util.getFileAsString("data/responses/invalids/signature_wrapping_attack.xml.base64");
 		String samlSigAttackStr = new String(Util.base64decoder(sigAttackStr));
 		Document samlSigAttackDocument = Util.loadXML(samlSigAttackStr);
-		assertFalse(Util.validateSign(samlSigAttackDocument, cert, null, null, true, false));
-		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, "SHA-1", true, false));
-		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, null, true, false));
-		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c1_sha256, "SHA-256", true, false));
+		assertFalse(Util.validateSign(samlSigAttackDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c1_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c2_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSigAttackDocument, null, fingerprint_c1_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
 	}
 
 	/**
@@ -1022,35 +1059,35 @@ public class UtilsTest {
 		String samlSignedResponseStr = new String(Util.base64decoder(signedResponseStr));
 		Document samlSignedResponseDocument = Util.loadXML(samlSignedResponseStr);
 
-		assertTrue(Util.validateSign(samlSignedResponseDocument, cert, null, null, true, false));
-		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, null, true, false));
-		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, "SHA-1", true, false));
-		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256", true, false));
-		assertFalse(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256", false, true));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256", RESPONSE_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedResponseDocument, null, fingerprint_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
 
 		// Signed Assertion Response
 		String signedAssertionStr = Util.getFileAsString("data/responses/signed_assertion_response.xml.base64");
 		String samlSignedAssertionStr = new String(Util.base64decoder(signedAssertionStr));
 		Document samlSignedAssertionDocument = Util.loadXML(samlSignedAssertionStr);
 		
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, cert, null, null, false, true));
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, null, false, true));
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, "SHA-1", false, true));
-		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha256, "SHA-256", false, true));
-		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha256, "SHA-256", true, false));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertFalse(Util.validateSign(samlSignedAssertionDocument, null, fingerprint_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
 
 		// Double Signed Response
 		String doubleSignedResponseStr = Util.getFileAsString("data/responses/double_signed_response.xml.base64");
 		String samlDoubleSignedResponseStr = new String(Util.base64decoder(doubleSignedResponseStr));
 		Document samlDoubleSignedResponseDocument = Util.loadXML(samlDoubleSignedResponseStr);
 
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, cert, null, null, true, true));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, null, true, true));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, "SHA-1", true, true));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", true, true));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", true, false));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", false, true));
-		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", false, false));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, cert, null, null, ASSERTION_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, cert, null, null, RESPONSE_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, null, ASSERTION_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, null, RESPONSE_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, "SHA-1", ASSERTION_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha1, "SHA-1", RESPONSE_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", ASSERTION_SIGNATURE_XPATH));
+		assertTrue(Util.validateSign(samlDoubleSignedResponseDocument, null, fingerprint_sha256, "SHA-256", RESPONSE_SIGNATURE_XPATH));
 	}
 
 	/**

--- a/core/src/test/resources/data/responses/invalids/attacks/response_with_spoofed_response_signature.xml
+++ b/core/src/test/resources/data/responses/invalids/attacks/response_with_spoofed_response_signature.xml
@@ -1,0 +1,35 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfx1ff1da4a-010e-428c-16eb-75f31f16567a" Version="2.0" IssueInstant="2014-02-19T01:37:01Z" Destination="http://localhost:8080/java-saml-jspsample/acs.jsp" InResponseTo="ONELOGIN_5fe9d6e499b2f0913206aab3f7191729049bb807">
+    <saml:Issuer>https://pitbulk.no-ip.org/simplesaml/saml2/idp/metadata.php</saml:Issuer>
+    <samlp:Extensions>
+    	<saml:Response ID="fakeSignature">
+    		<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+    <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+  <ds:Reference URI="#fakeSignature"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>V8b7Af25owMfcHaULaPjCkkBg48=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>FADE</ds:SignatureValue>
+<ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature>
+    	</saml:Response>
+    </samlp:Extensions>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="pfxa97e91c9-2aee-362a-b289-89d04af96d63" Version="2.0" IssueInstant="2014-02-19T01:37:01Z">
+        <saml:Issuer>https://pitbulk.no-ip.org/simplesaml/saml2/idp/metadata.php</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+    <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+  <ds:Reference URI="#pfxa97e91c9-2aee-362a-b289-89d04af96d63"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>V8b7Af25owMfcHaULaPjCkkBg48=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>A6OWfjpnyM15EDhVFFlzYo90C5FUXHMFeojIPrFGBRj2kASyAwPjbtmAEBp0BMYQ0FM+J6tvJDI1hW8UT25MKhScR+OQ9TTA8nB/l8le7q3AZJWslxakevZbLfxuw3gPIHPzz24Qdg3uKm2k/U4Ylg63SlpHg3LlF+2vetk0irk=</ds:SignatureValue>
+<ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature>
+        <saml:Subject>
+            <saml:NameID SPNameQualifier="http://localhost:8080/java-saml-jspsample/metadata.jsp" Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">
+                492882615acf31c8096b627245d76ae53036c090
+            </saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml:SubjectConfirmationData NotOnOrAfter="2023-08-23T06:57:01Z" Recipient="http://localhost:8080/java-saml-jspsample/acs.jsp" InResponseTo="ONELOGIN_5fe9d6e499b2f0913206aab3f7191729049bb807"/>
+            </saml:SubjectConfirmation>
+        </saml:Subject>
+        <saml:AuthnStatement AuthnInstant="2014-02-19T01:37:01Z" SessionNotOnOrAfter="2023-08-23T06:57:01Z" SessionIndex="_6273d77b8cde0c333ec79d22a9fa0003b9fe2d75cb">
+            <saml:AuthnContext>
+                <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+            </saml:AuthnContext>
+        </saml:AuthnStatement>
+    </saml:Assertion>
+</samlp:Response>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
   <logger name="com.base22" level="TRACE"/>
    
  
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/toolkit/src/test/resources/logback-test.xml
+++ b/toolkit/src/test/resources/logback-test.xml
@@ -10,7 +10,7 @@
   <logger name="com.base22" level="TRACE"/>
    
  
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
- checks that the found Signature elements match their expected schema locations, and that there's only one of each
- make sure the expected Signatures are always verified
- a few other small hardenings