### PR TITLE
V2.0.0 issue 80

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -310,7 +310,7 @@ public class LogoutResponse {
 		valueMap.put("issueInstant", issueInstantString);
 
 		String destinationStr = "";
-		URL slo =  settings.getIdpSingleLogoutServiceUrl();
+		URL slo =  settings.getIdpSingleLogoutServiceResponseUrl();
 		if (slo != null) {
 			destinationStr = " Destination=\"" + slo.toString() + "\"";
 		}

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -49,6 +49,7 @@ public class Saml2Settings {
 	private URL idpSingleSignOnServiceUrl = null;
 	private String idpSingleSignOnServiceBinding = Constants.BINDING_HTTP_REDIRECT;
 	private URL idpSingleLogoutServiceUrl = null;
+	private URL idpSingleLogoutServiceResponseUrl = null;
 	private String idpSingleLogoutServiceBinding = Constants.BINDING_HTTP_REDIRECT;
 	private X509Certificate idpx509cert = null;
 	private String idpCertFingerprint = null;
@@ -165,6 +166,17 @@ public class Saml2Settings {
 	 */
 	public final URL getIdpSingleLogoutServiceUrl() {
 		return idpSingleLogoutServiceUrl;
+	}
+
+	/**
+	 * @return the idpSingleLogoutServiceResponseUrl setting value
+	 */
+	public final URL getIdpSingleLogoutServiceResponseUrl() {
+		if (idpSingleLogoutServiceResponseUrl == null) {
+			return getIdpSingleLogoutServiceUrl();
+		}
+
+		return idpSingleLogoutServiceResponseUrl;
 	}
 
 	/**
@@ -453,6 +465,17 @@ public class Saml2Settings {
 	protected final void setIdpSingleLogoutServiceUrl(URL idpSingleLogoutServiceUrl) {
 		this.idpSingleLogoutServiceUrl = idpSingleLogoutServiceUrl;
 	}
+
+	/**
+	 * Set the idpSingleLogoutServiceUrl setting value
+	 *
+	 * @param idpSingleLogoutServiceResponseUrl
+	 *            the idpSingleLogoutServiceUrl value to be set
+	 */
+	protected final void setIdpSingleLogoutServiceResponseUrl(URL idpSingleLogoutServiceResponseUrl) {
+			this.idpSingleLogoutServiceResponseUrl = idpSingleLogoutServiceResponseUrl;
+	}
+
 
 	/**
 	 * Set the idpSingleLogoutServiceBinding setting value

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -61,6 +61,7 @@ public class SettingsBuilder {
 	public final static String IDP_SINGLE_SIGN_ON_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.url";
 	public final static String IDP_SINGLE_SIGN_ON_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.binding";
 	public final static String IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.url";
+	public final static String IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.response.url";
 	public final static String IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.binding";
 
 	public final static String IDP_X509CERT_PROPERTY_KEY = "onelogin.saml2.idp.x509cert";
@@ -192,6 +193,10 @@ public class SettingsBuilder {
 		URL idpSingleLogoutServiceUrl = loadURLProperty(IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY);
 		if (idpSingleLogoutServiceUrl != null)
 			saml2Setting.setIdpSingleLogoutServiceUrl(idpSingleLogoutServiceUrl);
+
+		URL idpSingleLogoutServiceResponseUrl = loadURLProperty(IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY);
+		if (idpSingleLogoutServiceResponseUrl != null)
+			saml2Setting.setIdpSingleLogoutServiceResponseUrl(idpSingleLogoutServiceResponseUrl);
 
 		String idpSingleLogoutServiceBinding = loadStringProperty(IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY);
 		if (idpSingleLogoutServiceBinding != null)

--- a/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
@@ -72,6 +72,7 @@ public class SettingBuilderTest {
 		assertNull(setting.getIdpSingleSignOnServiceUrl());
 		assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", setting.getIdpSingleSignOnServiceBinding());
 		assertNull(setting.getIdpSingleLogoutServiceUrl());
+		assertNull(setting.getIdpSingleLogoutServiceResponseUrl());
 		assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", setting.getIdpSingleLogoutServiceBinding());
 		assertNull(setting.getIdpx509cert());
 		assertNull(setting.getIdpCertFingerprint());
@@ -124,6 +125,7 @@ public class SettingBuilderTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SSOService.php", setting.getIdpSingleSignOnServiceUrl().toString());
 		assertEquals(setting.getIdpSingleSignOnServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceUrl().toString());
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceResponseUrl().toString());
 		assertEquals(setting.getIdpSingleLogoutServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertNotNull(setting.getIdpx509cert());
 		assertEquals(Util.loadCert(Util.getFileAsString("certs/certificate1")), setting.getIdpx509cert());
@@ -177,6 +179,7 @@ public class SettingBuilderTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SSOService.php", setting.getIdpSingleSignOnServiceUrl().toString());
 		assertEquals(setting.getIdpSingleSignOnServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceUrl().toString());
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutServiceResponse.php", setting.getIdpSingleLogoutServiceResponseUrl().toString());
 		assertEquals(setting.getIdpSingleLogoutServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertNotNull(setting.getIdpx509cert());
 		assertEquals(Util.loadCert(Util.getFileAsString("certs/certificate1")), setting.getIdpx509cert());
@@ -244,6 +247,7 @@ public class SettingBuilderTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SSOService.php", setting.getIdpSingleSignOnServiceUrl().toString());
 		assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", setting.getIdpSingleSignOnServiceBinding());
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceUrl().toString());
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceResponseUrl().toString());
 		assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", setting.getIdpSingleLogoutServiceBinding());
 		assertEquals(Util.loadCert(Util.getFileAsString("certs/certificate1")), setting.getIdpx509cert());
 
@@ -296,6 +300,7 @@ public class SettingBuilderTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SSOService.php", setting.getIdpSingleSignOnServiceUrl().toString());
 		assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", setting.getIdpSingleSignOnServiceBinding());
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceUrl().toString());
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceResponseUrl().toString());
 		assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", setting.getIdpSingleLogoutServiceBinding());
 		assertEquals(Util.loadCert(Util.getFileAsString("certs/certificate1")), setting.getIdpx509cert());
 
@@ -375,6 +380,7 @@ public class SettingBuilderTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SSOService.php", setting.getIdpSingleSignOnServiceUrl().toString());
 		assertEquals(setting.getIdpSingleSignOnServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceUrl().toString());
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", setting.getIdpSingleLogoutServiceResponseUrl().toString());
 		assertEquals(setting.getIdpSingleLogoutServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertNull(setting.getIdpx509cert());
 		assertEquals("4b6f70bb2cab82c86a8270f71a880b62e25bc2b3", setting.getIdpCertFingerprint());
@@ -426,6 +432,7 @@ public class SettingBuilderTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SSOService.php", setting.getIdpSingleSignOnServiceUrl().toString());
 		assertEquals(setting.getIdpSingleSignOnServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertNull(setting.getIdpSingleLogoutServiceUrl());
+		assertNull(setting.getIdpSingleLogoutServiceResponseUrl());
 		assertEquals(setting.getIdpSingleLogoutServiceBinding(), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect");
 		assertNull(setting.getIdpx509cert());
 		assertEquals("00d84fd17802a1f1edd9a03447ca1d3a6c2101a610a164ab898b880d01c44190", setting.getIdpCertFingerprint());

--- a/core/src/test/resources/config/config.all.properties
+++ b/core/src/test/resources/config/config.all.properties
@@ -56,6 +56,11 @@ onelogin.saml2.idp.single_sign_on_service.binding = urn:oasis:names:tc:SAML:2.0:
 # URL Location of the IdP where the SP will send the SLO Request
 onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
 
+# Optional SLO Response endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Response. If left blank, same URL as onelogin.saml2.idp.single_logout_service.url will be used.
+# Some IdPs use a separate URL for sending a logout request and response, use this property to set the separate response url
+onelogin.saml2.idp.single_logout_service.response.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutServiceResponse.php
+
 # SAML protocol binding to be used when returning the <Response>
 # message.  Onelogin Toolkit supports for this endpoint the
 # HTTP-Redirect binding only

--- a/core/src/test/resources/config/config.different.properties
+++ b/core/src/test/resources/config/config.different.properties
@@ -57,6 +57,11 @@ onelogin.saml2.idp.single_sign_on_service.binding = urn:oasis:names:tc:SAML:2.0:
 # URL Location of the IdP where the SP will send the SLO Request
 onelogin.saml2.idp.single_logout_service.url = invalid_slo_url
 
+# Optional SLO Response endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Response. If left blank, same URL as onelogin.saml2.idp.single_logout_service.url will be used.
+# Some IdPs use a separate URL for sending a logout request and response, use this property to set the separate response url
+onelogin.saml2.idp.single_logout_service.response.url = invalid_slo_response_url
+
 # SAML protocol binding to be used when returning the <Response>
 # message.  Onelogin Toolkit supports for this endpoint the
 # HTTP-Redirect binding only

--- a/core/src/test/resources/config/config.somevaluesempty.properties
+++ b/core/src/test/resources/config/config.somevaluesempty.properties
@@ -57,6 +57,11 @@ onelogin.saml2.idp.single_sign_on_service.binding = urn:oasis:names:tc:SAML:2.0:
 # URL Location of the IdP where the SP will send the SLO Request
 onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
 
+# Optional SLO Response endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Response. If left blank, same URL as onelogin.saml2.idp.single_logout_service.url will be used.
+# Some IdPs use a separate URL for sending a logout request and response, use this property to set the separate response url
+onelogin.saml2.idp.single_logout_service.response.url =
+
 # SAML protocol binding to be used when returning the <Response>
 # message.  Onelogin Toolkit supports for this endpoint the
 # HTTP-Redirect binding only

--- a/core/src/test/resources/onelogin.saml.properties
+++ b/core/src/test/resources/onelogin.saml.properties
@@ -22,5 +22,10 @@ onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesam
 # URL Location of the IdP where the SP will send the SLO Request
 onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
 
+# Optional SLO Response endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Response. If left blank, same URL as onelogin.saml2.idp.single_logout_service.url will be used.
+# Some IdPs use a separate URL for sending a logout request and response, use this property to set the separate response url
+onelogin.saml2.idp.single_logout_service.response.url =
+
 # Public x509 certificate of the IdP
 onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----

--- a/samples/java-saml-jspsample/src/main/resources/onelogin.saml.properties
+++ b/samples/java-saml-jspsample/src/main/resources/onelogin.saml.properties
@@ -65,6 +65,11 @@ onelogin.saml2.idp.single_sign_on_service.binding = urn:oasis:names:tc:SAML:2.0:
 # URL Location of the IdP where the SP will send the SLO Request
 onelogin.saml2.idp.single_logout_service.url =
 
+# Optional SLO Response endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Response. If left blank, same URL as onelogin.saml2.idp.single_logout_service.url will be used.
+# Some IdPs use a separate URL for sending a logout request and response, use this property to set the separate response url
+onelogin.saml2.idp.single_logout_service.response.url =
+
 # SAML protocol binding to be used when returning the <Response>
 # message.  Onelogin Toolkit supports for this endpoint the
 # HTTP-Redirect binding only

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -357,6 +357,17 @@ public class Auth {
 	}
 
 	/**
+ 	 * @return The url of the Single Logout Service Response.
+ 	 */
+	public String getSLOResponseUrl() {
+		if (settings.getIdpSingleLogoutServiceResponseUrl() == null) {
+			return settings.getIdpSingleLogoutServiceUrl().toString();
+		}
+
+		return settings.getIdpSingleLogoutServiceResponseUrl().toString();
+	}
+
+	/**
      * Process the SAML Response sent by the IdP.
      *
      * @param requestId
@@ -476,7 +487,7 @@ public class Auth {
 					parameters.put("Signature", signature);
 				}
 
-				String sloUrl = getSLOurl();
+				String sloUrl = getSLOResponseUrl();
 				LOGGER.debug("Logout response sent to " + sloUrl + " --> " + samlLogoutResponse);
 				ServletUtils.sendRedirect(response, sloUrl, parameters);
 			}

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -360,10 +360,6 @@ public class Auth {
  	 * @return The url of the Single Logout Service Response.
  	 */
 	public String getSLOResponseUrl() {
-		if (settings.getIdpSingleLogoutServiceResponseUrl() == null) {
-			return settings.getIdpSingleLogoutServiceUrl().toString();
-		}
-
 		return settings.getIdpSingleLogoutServiceResponseUrl().toString();
 	}
 

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -291,6 +291,29 @@ public class AuthTest {
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", auth.getSLOurl());
 	}
 
+
+	/**
+	 * Tests the getSLOResponseUrl method of Auth
+	 *
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 * @throws SettingsException
+	 *
+	 * @see com.onelogin.saml2.Auth#getSLOurl
+	 */
+	@Test
+	public void testGetSLOResponseurl() throws URISyntaxException, IOException, SettingsException {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
+		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.all.properties").build();
+
+		Auth auth = new Auth(settings, request, response);
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutServiceResponse.php", auth.getSLOResponseUrl());
+	}
+
 	/**
 	 * Tests the processResponse method of Auth
 	 *

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -544,7 +544,7 @@ public class AuthTest {
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();
-		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLResponse=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha512&Signature=(.)*"));
+		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutServiceResponse.php\\?SAMLResponse=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha512&Signature=(.)*"));
 		verify(session, times(1)).invalidate();
 		assertTrue(auth.getErrors().isEmpty());
 	}

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -194,6 +194,7 @@ public class AuthTest {
 		assertEquals(settings.getOrganization(), auth.getSettings().getOrganization());
 		assertEquals(settings.getIdpSingleSignOnServiceUrl().toString(), auth.getSettings().getIdpSingleSignOnServiceUrl().toString());
 		assertEquals(settings.getIdpSingleLogoutServiceUrl().toString(), auth.getSettings().getIdpSingleLogoutServiceUrl().toString());
+		assertEquals(settings.getIdpSingleLogoutServiceResponseUrl().toString(), auth.getSettings().getIdpSingleLogoutServiceResponseUrl().toString());
 		assertEquals(settings.getIdpx509cert().hashCode(), auth.getSettings().getIdpx509cert().hashCode());
 		assertEquals(settings.getSpAssertionConsumerServiceUrl().toString(), auth.getSettings().getSpAssertionConsumerServiceUrl().toString());
 		assertEquals(settings.getSpSingleLogoutServiceUrl().toString(), auth.getSettings().getSpSingleLogoutServiceUrl().toString());

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -299,10 +299,10 @@ public class AuthTest {
 	 * @throws URISyntaxException
 	 * @throws SettingsException
 	 *
-	 * @see com.onelogin.saml2.Auth#getSLOurl
+	 * @see com.onelogin.saml2.Auth#getSLOResponseUrl
 	 */
 	@Test
-	public void testGetSLOResponseurl() throws URISyntaxException, IOException, SettingsException {
+	public void testGetSLOResponseUrl() throws URISyntaxException, IOException, SettingsException {
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
@@ -312,6 +312,28 @@ public class AuthTest {
 
 		Auth auth = new Auth(settings, request, response);
 		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutServiceResponse.php", auth.getSLOResponseUrl());
+	}
+
+	/**
+	 * Tests the getSLOResponseUrl method of Auth. Verifies a null value will return the same output as getSLOurl()
+	 *
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 * @throws SettingsException
+	 *
+	 * @see com.onelogin.saml2.Auth#getSLOResponseUrl
+	 */
+	@Test
+	public void testGetSLOResponseUrlNull() throws URISyntaxException, IOException, SettingsException {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
+		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+
+		Auth auth = new Auth(settings, request, response);
+		assertEquals("http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php", auth.getSLOResponseUrl());
 	}
 
 	/**


### PR DESCRIPTION
Added a property which can allow the library to use separate URLs for SLO request/response. New property value

onelogin.saml2.idp.single_logout_service.response.url

If the new property is not set/blank/invalid url, the logout url specified with onelogin.saml2.idp.single_logout_service.url will be used.