### PR TITLE
fixes #83: don't share a SchemaFactory between instances

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/util/SchemaFactory.java
+++ b/core/src/main/java/com/onelogin/saml2/util/SchemaFactory.java
@@ -13,15 +13,13 @@ import org.xml.sax.SAXException;
  * A class that read SAML schemas that will be used to validate XMLs of the OneLogin's Java Toolkit 
  */ 
 public abstract class SchemaFactory {
-	public static final javax.xml.validation.SchemaFactory schemaFactory = javax.xml.validation.SchemaFactory
-			.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-
 	public static final URL SAML_SCHEMA_METADATA_2_0 = SchemaFactory.class
 			.getResource("/schemas/saml-schema-metadata-2.0.xsd");
 	public static final URL SAML_SCHEMA_PROTOCOL_2_0 = SchemaFactory.class
 			.getResource("/schemas/saml-schema-protocol-2.0.xsd");
 
 	public static Schema loadFromUrl(URL schemaUrl) throws SAXException {
-		return schemaFactory.newSchema(schemaUrl);
+		return javax.xml.validation.SchemaFactory
+                .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema(schemaUrl);
 	}
 }


### PR DESCRIPTION
Avoid sharing a static `javax.xml.validation.SchemaFactory` which is not thread safe - this caused failures when trying to do process Responses in multiple threads concurrently.