### PR TITLE
Adds UTF-8 encoding when converting bytes to string

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -120,7 +120,7 @@ public class SamlResponse {
 	 * @throws ValidationError
 	 */
 	public void loadXmlFromBase64(String responseStr) throws ParserConfigurationException, XPathExpressionException, SAXException, IOException, SettingsException, ValidationError {
-		samlResponseString = new String(Util.base64decoder(responseStr));
+		samlResponseString = new String(Util.base64decoder(responseStr), "UTF-8");
 		samlResponseDocument = Util.loadXML(samlResponseString);
 
 		if (samlResponseDocument == null) {

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -329,7 +329,16 @@ public final class Util {
 		} else {
 			XMLUtils.outputDOM(doc, baos);
 		}
-		return baos.toString();
+		
+		return Util.toUtf8String(baos.toByteArray());
+	}
+
+	private static String toUtf8String(byte[] bytes) {
+		try {
+			return new String(bytes, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 	/**


### PR DESCRIPTION
XML validation fails when the JVM does not use UTF-8 as the default
encoding.  Added UTF-8 encoding in byte to string conversions in:
  * SamlResponse - after base64decode SAMLResponse
  * Util.convertDocumentToString()