### PR TITLE
Add onelogin.saml2.organization.lang attribute  

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ onelogin.saml2.security.signature_algorithm = http://www.w3.org/2000/09/xmldsig#
 onelogin.saml2.organization.name = SP Java 
 onelogin.saml2.organization.displayname = SP Java Example
 onelogin.saml2.organization.url = http://sp.example.com
+onelogin.saml2.organization.lang = en
 
 # Contacts
 onelogin.saml2.contacts.technical.given_name = Technical Guy

--- a/core/src/main/java/com/onelogin/saml2/model/Organization.java
+++ b/core/src/main/java/com/onelogin/saml2/model/Organization.java
@@ -2,6 +2,8 @@ package com.onelogin.saml2.model;
 
 import java.net.URL;
 
+import org.apache.commons.lang3.StringUtils;
+
 
 /**
  * Organization class of OneLogin's Java Toolkit.
@@ -23,6 +25,11 @@ public class Organization {
      * Organization URL
      */
 	private final String orgUrl;
+	
+	/**
+	 * Organization lang attribute
+	 */
+	private final String orgLangAttribute;
 
 	/**
 	 * Constructor
@@ -33,11 +40,26 @@ public class Organization {
      *				String. Organization display name
 	 * @param orgUrl
      *				URL. Organization URL
+     * @param orgLangAttribute
+     * 				The xml lang attribute, describing name and display name
+	 */
+	public Organization(String orgName, String orgDisplayName, URL orgUrl, String orgLangAttribute) {
+		this(orgName, orgDisplayName, orgUrl != null ? orgUrl.toString() : "", orgLangAttribute);
+	}
+	
+	/**
+	 * Constructor<br>
+	 * Default the lang attribute to "en"
+	 *
+	 * @param orgName
+	 *              String. Organization name
+	 * @param orgDisplayName
+     *				String. Organization display name
+	 * @param orgUrl
+     *				URL. Organization URL
 	 */
 	public Organization(String orgName, String orgDisplayName, URL orgUrl) {
-		this.orgName = orgName != null ? orgName : "";
-		this.orgDisplayName = orgDisplayName != null ? orgDisplayName : "";
-		this.orgUrl = orgUrl != null ? orgUrl.toString() : "";
+		this(orgName, orgDisplayName, orgUrl, "en");
 	}
 
 	/**
@@ -49,11 +71,29 @@ public class Organization {
      *				String. Organization display name
 	 * @param orgUrl
      *				String. Organization URL
+     * @param orgLangAttribute
+     * 				The xml lang attribute, describing name and display name
 	 */
-	public Organization(String orgName, String orgDisplayName, String orgUrl) {
+	public Organization(String orgName, String orgDisplayName, String orgUrl, String orgLangAttribute) {
 		this.orgName = orgName != null ? orgName : "";
 		this.orgDisplayName = orgDisplayName != null ? orgDisplayName : "";
 		this.orgUrl = orgUrl != null ? orgUrl : "";
+		this.orgLangAttribute = StringUtils.defaultIfBlank(orgLangAttribute, "en");
+	}
+	
+	/**
+	 * Constructor<br>
+	 * Default the lang attribute to "en"
+	 *
+	 * @param orgName
+	 *              String. Organization name
+	 * @param orgDisplayName
+     *				String. Organization display name
+	 * @param orgUrl
+     *				String. Organization URL
+	 */
+	public Organization(String orgName, String orgDisplayName, String orgUrl) {
+		this(orgName, orgDisplayName, orgUrl, "en");
 	}
 
 	/**
@@ -76,6 +116,13 @@ public class Organization {
 	public final String getOrgUrl() {
 		return orgUrl;
 	}
+	
+	/**
+	 * @return string the lang attribute
+	 */
+	public final String getOrgLangAttribute() {
+		return orgLangAttribute;
+	}	
 
 	/**
 	 * Compare with another organization
@@ -85,6 +132,6 @@ public class Organization {
 	 * @return boolean true if organizations are equals
 	 */
 	public final Boolean equalsTo(Organization org) {
-		return orgName.equals(org.getOrgName()) && orgDisplayName.equals(org.getOrgDisplayName()) && orgUrl.equals(org.getOrgUrl());
+		return orgName.equals(org.getOrgName()) && orgDisplayName.equals(org.getOrgDisplayName()) && orgUrl.equals(org.getOrgUrl()) && orgLangAttribute.equals(org.getOrgLangAttribute());
 	}	
 }

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -152,7 +152,7 @@ public class Metadata {
 		
 		valueMap.put("strKeyDescriptor", toX509KeyDescriptorsXML(settings.getSPcert()));
 		valueMap.put("strContacts", toContactsXml(settings.getContacts()));
-		valueMap.put("strOrganization", toOrganizationXml(settings.getOrganization(), "en"));
+		valueMap.put("strOrganization", toOrganizationXml(settings.getOrganization()));
 
 		return new StrSubstitutor(valueMap);
 	}
@@ -271,19 +271,13 @@ public class Metadata {
 	 *
 	 * @param organization
 	 * 				organization object
-	 * @param lang
-	 * 				language
-	 *
 	 *  @return the organization section of the metadata's template
 	 */
-	private String toOrganizationXml(Organization organization, String lang) {
+	private String toOrganizationXml(Organization organization) {
 		String orgXml = "";
 
-		if (lang == null) {
-			lang = "en";
-		}
-
 		if (organization != null) {
+			String lang = organization.getOrgLangAttribute();
 			orgXml = "<md:Organization><md:OrganizationName xml:lang=\"" + lang + "\">" + organization.getOrgName()
 					+ "</md:OrganizationName><md:OrganizationDisplayName xml:lang=\"" + lang + "\">"
 					+ organization.getOrgDisplayName() + "</md:OrganizationDisplayName><md:OrganizationURL xml:lang=\""

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -98,6 +98,7 @@ public class SettingsBuilder {
 	public final static String ORGANIZATION_NAME = "onelogin.saml2.organization.name";
 	public final static String ORGANIZATION_DISPLAYNAME = "onelogin.saml2.organization.displayname";
 	public final static String ORGANIZATION_URL = "onelogin.saml2.organization.url";
+	public final static String ORGANIZATION_LANG = "onelogin.saml2.organization.lang";
 
 	/**
 	 * Load settings from the file
@@ -324,9 +325,10 @@ public class SettingsBuilder {
 		String orgName = loadStringProperty(ORGANIZATION_NAME);
 		String orgDisplayName = loadStringProperty(ORGANIZATION_DISPLAYNAME);
 		URL orgUrl = loadURLProperty(ORGANIZATION_URL);
+		String orgLangAttribute = loadStringProperty(ORGANIZATION_LANG);
 
 		if ((orgName != null && !orgName.isEmpty()) || (orgDisplayName != null && !orgDisplayName.isEmpty()) || (orgUrl != null)) {
-			orgResult = new Organization(orgName, orgDisplayName, orgUrl);
+			orgResult = new Organization(orgName, orgDisplayName, orgUrl, orgLangAttribute);
 		}
 
 		return orgResult;

--- a/core/src/test/java/com/onelogin/saml2/test/model/OrganizationTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/model/OrganizationTest.java
@@ -17,7 +17,7 @@ import com.onelogin.saml2.model.Organization;
 public class OrganizationTest {
 
 	/**
-	 * Tests the Organization constructor
+	 * Tests the Organization constructors
 	 *
 	 * @throws MalformedURLException
 	 *
@@ -30,29 +30,58 @@ public class OrganizationTest {
 		assertEquals("", org.getOrgName());
 		assertEquals("", org.getOrgDisplayName());
 		assertEquals("", org.getOrgUrl());
+		assertEquals("en", org.getOrgLangAttribute());
 
 		String urlStr = null;
 		Organization org2 = new Organization(null, null, urlStr);
 		assertEquals("", org2.getOrgName());
 		assertEquals("", org2.getOrgDisplayName());
 		assertEquals("", org2.getOrgUrl());
+		assertEquals("en", org2.getOrgLangAttribute());
 
 		URL urlExample = new URL("http://example.com");
 		Organization org3 = new Organization("", "", urlExample);
 		assertEquals("", org3.getOrgName());
 		assertEquals("", org3.getOrgDisplayName());
 		assertEquals("http://example.com", org3.getOrgUrl());
+		assertEquals("en", org3.getOrgLangAttribute());
 
 		String urlExampleStr = "http://example.com";
 		Organization org4 = new Organization("", "", urlExampleStr);
 		assertEquals("", org4.getOrgName());
 		assertEquals("", org4.getOrgDisplayName());
 		assertEquals("http://example.com", org4.getOrgUrl());
+		assertEquals("en", org4.getOrgLangAttribute());
 
 		Organization org5 = new Organization("OrgName", "DisplayName", urlExampleStr);
 		assertEquals("OrgName", org5.getOrgName());
 		assertEquals("DisplayName", org5.getOrgDisplayName());
 		assertEquals("http://example.com", org5.getOrgUrl());
+		assertEquals("en", org5.getOrgLangAttribute());
+		
+		Organization org6 = new Organization("NomOrg", "DisplayName", urlExampleStr, "fr");
+		assertEquals("NomOrg", org6.getOrgName());
+		assertEquals("DisplayName", org6.getOrgDisplayName());
+		assertEquals("http://example.com", org6.getOrgUrl());
+		assertEquals("fr", org6.getOrgLangAttribute());
+		
+		Organization org7 = new Organization("NomOrg", "DisplayName", urlExample, "fr");
+		assertEquals("NomOrg", org7.getOrgName());
+		assertEquals("DisplayName", org7.getOrgDisplayName());
+		assertEquals("http://example.com", org7.getOrgUrl());
+		assertEquals("fr", org7.getOrgLangAttribute());
+		
+		Organization org8 = new Organization("OrgName", "DisplayName", urlExampleStr, "");
+		assertEquals("OrgName", org8.getOrgName());
+		assertEquals("DisplayName", org8.getOrgDisplayName());
+		assertEquals("http://example.com", org8.getOrgUrl());
+		assertEquals("en", org8.getOrgLangAttribute());
+		
+		Organization org9 = new Organization("OrgName", "DisplayName", urlExampleStr, null);
+		assertEquals("OrgName", org9.getOrgName());
+		assertEquals("DisplayName", org9.getOrgDisplayName());
+		assertEquals("http://example.com", org9.getOrgUrl());
+		assertEquals("en", org9.getOrgLangAttribute());
 	}
 
 	/**
@@ -67,11 +96,14 @@ public class OrganizationTest {
 		Organization org3 = new Organization("SP Java 3", "SP Java Example", "http://sp.example.com");
 		Organization org4 = new Organization("SP Java", "SP Java Example 4", "http://sp.example.com");
 		Organization org5 = new Organization("SP Java", "SP Java Example", "http://sp.example.com/5");
-		Organization org6 = new Organization("SP Java 6", "SP Java Example 6", "http://sp.example.com/6");
+		Organization org6 = new Organization("SP Java", "SP Java Example", "http://sp.example.com", "en");
+		Organization org7 = new Organization("SP Java", "SP Java Example", "http://sp.example.com", "fr");
 
 		assertTrue(org.equalsTo(org2));
 		assertFalse(org.equalsTo(org3));
 		assertFalse(org.equalsTo(org4));
 		assertFalse(org.equalsTo(org5));
+		assertTrue(org.equalsTo(org6));
+		assertFalse(org.equalsTo(org7));
 	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
@@ -143,6 +143,57 @@ public class MetadataTest {
 
 		assertThat(metadataStr2, not(containsString(orgStr)));
 	}
+	
+	/**
+	 * Tests the toOrganizationXml method of Metadata without any "lang" attribute
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 *
+	 * @see com.onelogin.saml2.settings.Metadata#toOrganizationXml
+	 */
+	@Test
+	public void testToNonLocalizedOrganizationXml() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.org.properties").build();
+		Metadata metadataObj = new Metadata(settings);
+		String metadataStr = metadataObj.getMetadataString();
+		
+		String orgStr = "<md:Organization><md:OrganizationName xml:lang=\"en\">SP Java</md:OrganizationName><md:OrganizationDisplayName xml:lang=\"en\">SP Java Example</md:OrganizationDisplayName><md:OrganizationURL xml:lang=\"en\">http://sp.example.com</md:OrganizationURL></md:Organization>";
+		assertThat(metadataStr, containsString(orgStr));
+
+		Saml2Settings settings2 = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		Metadata metadataObj2 = new Metadata(settings2);
+		String metadataStr2 = metadataObj2.getMetadataString();
+
+		assertThat(metadataStr2, not(containsString(orgStr)));
+	}
+
+	
+	/**
+	 * Tests the toOrganizationXml method of Metadata using a non default "lang" attribute
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 *
+	 * @see com.onelogin.saml2.settings.Metadata#toOrganizationXml
+	 */
+	@Test
+	public void testToLocalizedOrganizationXml() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.org.localized.properties").build();
+		Metadata metadataObj = new Metadata(settings);
+		String metadataStr = metadataObj.getMetadataString();
+		
+		String orgStr = "<md:Organization><md:OrganizationName xml:lang=\"fr\">SP Java</md:OrganizationName><md:OrganizationDisplayName xml:lang=\"fr\">SP Exemple Java</md:OrganizationDisplayName><md:OrganizationURL xml:lang=\"fr\">http://sp.example.com/fr</md:OrganizationURL></md:Organization>";
+		assertThat(metadataStr, containsString(orgStr));
+
+		Saml2Settings settings2 = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		Metadata metadataObj2 = new Metadata(settings2);
+		String metadataStr2 = metadataObj2.getMetadataString();
+
+		assertThat(metadataStr2, not(containsString(orgStr)));
+	}
 
 	/**
 	 * Tests the toSLSXml method of Metadata

--- a/core/src/test/resources/config/config.all.properties
+++ b/core/src/test/resources/config/config.all.properties
@@ -131,6 +131,7 @@ onelogin.saml2.security.signature_algorithm = http://www.w3.org/2001/04/xmldsig-
 onelogin.saml2.organization.name = SP Java 
 onelogin.saml2.organization.displayname = SP Java Example
 onelogin.saml2.organization.url = http://sp.example.com
+onelogin.saml2.organization.lang = en
 
 # Contacts
 onelogin.saml2.contacts.technical.given_name = Technical Guy

--- a/core/src/test/resources/config/config.org.localized.properties
+++ b/core/src/test/resources/config/config.org.localized.properties
@@ -1,0 +1,32 @@
+config.all.properties#  Service Provider Data that we are deploying
+#  Identifier of the SP entity  (must be a URI)
+onelogin.saml2.sp.entityid = http://localhost:8080/java-saml-jspsample/metadata.jsp
+# Specifies info about where and how the <AuthnResponse> message MUST be
+#  returned to the requester, in this case our SP.
+# URL Location where the <Response> from the IdP will be returned
+onelogin.saml2.sp.assertion_consumer_service.url = http://localhost:8080/java-saml-jspsample/acs.jsp
+
+# Specifies info about Logout service
+# URL Location where the <LogoutResponse> from the IdP will be returned or where to send the <LogoutRequest>
+onelogin.saml2.sp.single_logout_service.url = http://localhost:8080/java-saml-jspsample/sls.jsp
+
+# Identity Provider Data that we want connect with our SP
+# Identifier of the IdP entity  (must be a URI)
+onelogin.saml2.idp.entityid = http://idp.example.com/
+
+# SSO endpoint info of the IdP. (Authentication Request protocol)
+# URL Target of the IdP where the SP will send the Authentication Request Message
+onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesaml/saml2/idp/SSOService.php
+
+# SLO endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Request
+onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
+
+# Public x509 certificate of the IdP
+onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----
+
+# Organization
+onelogin.saml2.organization.name = SP Java 
+onelogin.saml2.organization.displayname = SP Exemple Java
+onelogin.saml2.organization.url = http://sp.example.com/fr
+onelogin.saml2.organization.lang = fr

--- a/core/src/test/resources/config/config.org.properties
+++ b/core/src/test/resources/config/config.org.properties
@@ -1,0 +1,31 @@
+config.all.properties#  Service Provider Data that we are deploying
+#  Identifier of the SP entity  (must be a URI)
+onelogin.saml2.sp.entityid = http://localhost:8080/java-saml-jspsample/metadata.jsp
+# Specifies info about where and how the <AuthnResponse> message MUST be
+#  returned to the requester, in this case our SP.
+# URL Location where the <Response> from the IdP will be returned
+onelogin.saml2.sp.assertion_consumer_service.url = http://localhost:8080/java-saml-jspsample/acs.jsp
+
+# Specifies info about Logout service
+# URL Location where the <LogoutResponse> from the IdP will be returned or where to send the <LogoutRequest>
+onelogin.saml2.sp.single_logout_service.url = http://localhost:8080/java-saml-jspsample/sls.jsp
+
+# Identity Provider Data that we want connect with our SP
+# Identifier of the IdP entity  (must be a URI)
+onelogin.saml2.idp.entityid = http://idp.example.com/
+
+# SSO endpoint info of the IdP. (Authentication Request protocol)
+# URL Target of the IdP where the SP will send the Authentication Request Message
+onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesaml/saml2/idp/SSOService.php
+
+# SLO endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Request
+onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
+
+# Public x509 certificate of the IdP
+onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----
+
+# Organization
+onelogin.saml2.organization.name = SP Java 
+onelogin.saml2.organization.displayname = SP Java Example
+onelogin.saml2.organization.url = http://sp.example.com

--- a/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
+++ b/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
@@ -151,6 +151,7 @@ onelogin.saml2.security.signature_algorithm = http://www.w3.org/2000/09/xmldsig#
 onelogin.saml2.organization.name = SP Java 
 onelogin.saml2.organization.displayname = SP Java Example
 onelogin.saml2.organization.url = http://sp.example.com
+onelogin.saml2.organization.lang = 
 
 # Contacts
 onelogin.saml2.contacts.technical.given_name = Technical Guy


### PR DESCRIPTION
I put the attribute into the `Organization`, class,  and overloaded the constructors, leaving the existing ones with a "en" default value.

This PR allows us to change this attribute without breaking existing configurations (including programmatic ones), even though it won't fully answer issue #102 