### PR TITLE
Patch for Util.java to fix decoding issue when message > 2048 

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -642,9 +642,13 @@ public final class Util {
 		
 		// Inflater
 		try {
-			Inflater decompresser = new Inflater(true);
+		    Inflater decompresser = new Inflater(true);
 		    decompresser.setInput(decoded);
-		    byte[] result = new byte[2048];
+		    int resultBytes = 1;
+		    while (resultBytes <= decoded.length) {
+			    resultBytes *= 2;
+		    }
+		    byte[] result = new byte[resultBytes];
 		    int resultLength = decompresser.inflate(result);
 		    decompresser.end();
 

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -644,7 +644,7 @@ public final class Util {
 		try {
 		    Inflater decompresser = new Inflater(true);
 		    decompresser.setInput(decoded);
-		    int resultBytes = 1;
+		    int resultBytes = 2048;
 		    while (resultBytes <= decoded.length) {
 			    resultBytes *= 2;
 		    }


### PR DESCRIPTION
Fix the base64decodedInflated where return input string after base 64 decode is greater than 2048 bytes will cause decompressed XML to have invalid format.