### PR TITLE
Allow java-saml to be used in non-JavaEE containers

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/http/HttpRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/http/HttpRequest.java
@@ -1,151 +1,61 @@
 package com.onelogin.saml2.http;
 
-import static com.onelogin.saml2.util.Preconditions.checkNotNull;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
+import com.onelogin.saml2.util.Util;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.commons.lang3.StringUtils;
-
-import com.onelogin.saml2.util.Util;
 
 /**
  * Framework-agnostic representation of an HTTP request.
  *
  * @since 2.0.0
  */
-public final class HttpRequest {
-
-    public static final Map<String, List<String>> EMPTY_PARAMETERS = Collections.<String, List<String>>emptyMap();
-
-    private final String requestURL;
-    private final Map<String, List<String>> parameters;
-    private final String queryString;
+public abstract class HttpRequest {
 
     /**
-     * Creates a new HttpRequest.
-     *
-     * @param requestURL the request URL (up to but not including query parameters)
-     * @throws NullPointerException if requestURL is null
-     * @deprecated Not providing a queryString can cause HTTP Redirect binding to fail.
+     * @return true if the request is using a secure scheme (HTTPS)
      */
-    @Deprecated
-    public HttpRequest(String requestURL) {
-        this(requestURL, EMPTY_PARAMETERS);
-    }
+    public abstract boolean isSecure();
 
     /**
-     * Creates a new HttpRequest.
-     *
-     * @param requestURL  the request URL (up to but not including query parameters)
-     * @param queryString string that is contained in the request URL after the path
+     * @return the name of the request protocol (HTTP / HTTPS)
      */
-    public HttpRequest(String requestURL, String queryString) {
-        this(requestURL, EMPTY_PARAMETERS, queryString);
-    }
+    public abstract String getScheme();
 
     /**
-     * Creates a new HttpRequest.
-     *
-     * @param requestURL  the request URL (up to but not including query parameters)
-     * @param parameters the request query parameters
-     * @throws NullPointerException if any of the parameters is null
-     * @deprecated Not providing a queryString can cause HTTP Redirect binding to fail.
+     * @return the server name in the request e.g. www.example.com
      */
-    @Deprecated
-    public HttpRequest(String requestURL, Map<String, List<String>> parameters) {
-        this(requestURL, parameters, null);
-    }
+    public abstract String getServerName();
 
     /**
-     * Creates a new HttpRequest.
-     *
-     * @param requestURL  the request URL (up to but not including query parameters)
-     * @param parameters the request query parameters
-     * @param queryString string that is contained in the request URL after the path
-     * @throws NullPointerException if any of the parameters is null
+     * @return the port over which the request is made e.g. 80 or 443
      */
-    public HttpRequest(String requestURL, Map<String, List<String>> parameters, String queryString) {
-        this.requestURL = checkNotNull(requestURL, "requestURL");
-        this.parameters = unmodifiableCopyOf(checkNotNull(parameters, "queryParams"));
-        this.queryString = StringUtils.trimToEmpty(queryString);
-    }
+    public abstract int getServerPort();
 
     /**
-     * @param name  the query parameter name
-     * @param value the query parameter value
-     * @return a new HttpRequest with the given query parameter added
-     * @throws NullPointerException if any of the parameters is null
+     * @return the query string part of the URL
      */
-    public HttpRequest addParameter(String name, String value) {
-        checkNotNull(name, "name");
-        checkNotNull(value, "value");
-
-        final List<String> oldValues = parameters.containsKey(name) ? parameters.get(name) : new ArrayList<String>();
-        final List<String> newValues = new ArrayList<>(oldValues);
-        newValues.add(value);
-        final Map<String, List<String>> params = new HashMap<>(parameters);
-        params.put(name, newValues);
-
-        return new HttpRequest(requestURL, params, queryString);
-    }
+    public abstract String getQueryString();
 
     /**
-     * @param name  the query parameter name
-     * @return a new HttpRequest with the given query parameter removed
-     * @throws NullPointerException if any of the parameters is null
+     * @return the URI the client used to make the request - only includes
+     * the server path, but not the query string parameters.
      */
-    public HttpRequest removeParameter(String name) {
-        checkNotNull(name, "name");
+    public abstract String getRequestURI();
 
-        final Map<String, List<String>> params = new HashMap<>(parameters);
-        params.remove(name);
-
-        return new HttpRequest(requestURL, params, queryString);
-    }
-    
     /**
      * The URL the client used to make the request. Includes a protocol, server name, port number, and server path, but
      * not the query string parameters.
      *
      * @return the request URL
      */
-    public String getRequestURL() {
-        return requestURL;
-    }
+    public abstract String getRequestURL();
 
     /**
      * @param name the query parameter name
      * @return the first value for the parameter, or null
      */
-    public String getParameter(String name) {
-        List<String> values = getParameters(name);
-        return values.isEmpty() ? null : values.get(0);
-    }
-
-    /**
-     * @param name the query parameter name
-     * @return a List containing all values for the parameter
-     */
-    public List<String> getParameters(String name) {
-        List<String> values = parameters.get(name);
-        return values != null ? values : Collections.<String>emptyList();
-    }
-
-    /**
-     * @return a map of all query parameters
-     */
-    public Map<String, List<String>> getParameters() {
-        return parameters;
-    }
+    public abstract String getParameter(String name);
 
     /**
      * Return an url encoded get parameter value
@@ -155,8 +65,8 @@ public final class HttpRequest {
      * @param name
      * @return the first value for the parameter, or null
      */
-    public String getEncodedParameter(String name) {
-        Matcher matcher = Pattern.compile(Pattern.quote(name) + "=([^&#]+)").matcher(queryString);
+    public final String getEncodedParameter(String name) {
+        Matcher matcher = Pattern.compile(Pattern.quote(name) + "=([^&#]+)").matcher(getQueryString());
         if (matcher.find()) {
             return matcher.group(1);
         } else {
@@ -173,49 +83,13 @@ public final class HttpRequest {
      * @param defaultValue
      * @return the first value for the parameter, or url encoded default value
      */
-    public String getEncodedParameter(String name, String defaultValue) {
-            String value = getEncodedParameter(name);
-            return (value != null ? value : Util.urlEncoder(defaultValue));
+    public final String getEncodedParameter(String name, String defaultValue) {
+        String value = getEncodedParameter(name);
+        return (value != null ? value : Util.urlEncoder(defaultValue));
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-        	return true;
-        }
-
-        if (o == null || getClass() != o.getClass()) {
-        	return false;
-        }
-
-        HttpRequest that = (HttpRequest) o;
-        return Objects.equals(requestURL, that.requestURL) &&
-                Objects.equals(parameters, that.parameters) &&
-                Objects.equals(queryString, that.queryString);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(requestURL, parameters, queryString);
-    }
-
-    @Override
-    public String toString() {
-        return "HttpRequest{" +
-                "requestURL='" + requestURL + '\'' +
-                ", parameters=" + parameters +
-                ", queryString=" + queryString +
-                '}';
-    }
-
-    private static Map<String, List<String>> unmodifiableCopyOf(Map<String, List<String>> orig) {
-        Map<String, List<String>> copy = new HashMap<>();
-        for (Map.Entry<String, List<String>> entry : orig.entrySet()) {
-            copy.put(entry.getKey(), unmodifiableList(new ArrayList<>(entry.getValue())));
-        }
-
-        return unmodifiableMap(copy);
-    }
-
-
+    /**
+     * Invalidate the current session
+     */
+    public abstract void invalidateSession();
 }

--- a/core/src/main/java/com/onelogin/saml2/http/HttpResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/http/HttpResponse.java
@@ -1,0 +1,21 @@
+package com.onelogin.saml2.http;
+
+import java.io.IOException;
+
+/**
+ * Framework-agnostic representation of an HTTP response.
+ *
+ * @since 2.2.0
+ */
+public abstract class HttpResponse {
+
+    /**
+     * Sends an HTTP redirect to the target URL
+     *
+     * @param target
+     *          the URL to redirect to
+     * @throws IOException
+     *          if the redirect could not be sent
+     */
+    public abstract void sendRedirect(String target) throws IOException;
+}

--- a/core/src/main/java/com/onelogin/saml2/servlet/ServletUtils.java
+++ b/core/src/main/java/com/onelogin/saml2/servlet/ServletUtils.java
@@ -1,58 +1,35 @@
 package com.onelogin.saml2.servlet;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.onelogin.saml2.http.HttpRequest;
+import com.onelogin.saml2.http.HttpResponse;
 import com.onelogin.saml2.util.Util;
 
 /**
  * ServletUtils class of OneLogin's Java Toolkit.
  *
- * A class that contains several auxiliary methods related to HttpServletRequest and HttpServletResponse
+ * A class that contains several auxiliary methods related to HttpRequest and HttpResponse
  */
 public class ServletUtils {
 
 	private ServletUtils() {
 	      //not called
 	}
-	
-	/**
-     * Creates an HttpRequest from an HttpServletRequest.
-     *
-     * @param req the incoming HttpServletRequest
-     * @return a HttpRequest
-     */
-    public static HttpRequest makeHttpRequest(HttpServletRequest req) {
-    	@SuppressWarnings("unchecked")
-        final Map<String, String[]> paramsAsArray = (Map<String, String[]>) req.getParameterMap();
-        final Map<String, List<String>> paramsAsList = new HashMap<>();
-        for (Map.Entry<String, String[]> param : paramsAsArray.entrySet()) {
-            paramsAsList.put(param.getKey(), Arrays.asList(param.getValue()));
-        }
-
-        return new HttpRequest(req.getRequestURL().toString(), paramsAsList, req.getQueryString());
-    }
 
     /**
      * Returns the protocol + the current host + the port (if different than
      * common ports).
      *
      * @param request
-     * 				HttpServletRequest object to be processed
+     * 				HttpRequest object to be processed
      *
      * @return the HOST URL
      */
-    public static String getSelfURLhost(HttpServletRequest request) {
-        String hostUrl = StringUtils.EMPTY;
+    public static String getSelfURLhost(HttpRequest request) {
+        final String hostUrl;
         final int serverPort = request.getServerPort();
         if ((serverPort == 80) || (serverPort == 443) || serverPort == 0) {
             hostUrl = String.format("%s://%s", request.getScheme(), request.getServerName());
@@ -64,11 +41,11 @@ public class ServletUtils {
 
     /**
      * @param request
-     * 				HttpServletRequest object to be processed
+     * 				HttpRequest object to be processed
      *
      * @return the server name
      */
-    public static String getSelfHost(HttpServletRequest request) {
+    public static String getSelfHost(HttpRequest request) {
         return request.getServerName();
     }
 
@@ -76,11 +53,11 @@ public class ServletUtils {
      * Check if under https or http protocol
      *
      * @param request
-     * 				HttpServletRequest object to be processed
+     * 				HttpRequest object to be processed
      *
      * @return false if https is not active
      */
-    public static boolean isHTTPS(HttpServletRequest request) {
+    public static boolean isHTTPS(HttpRequest request) {
         return request.isSecure();
     }
 
@@ -88,11 +65,11 @@ public class ServletUtils {
      * Returns the URL of the current context + current view + query
      *
      * @param request
-     * 				HttpServletRequest object to be processed
+     * 				HttpRequest object to be processed
      *
      * @return current context + current view + query
      */
-    public static String getSelfURL(HttpServletRequest request) {
+    public static String getSelfURL(HttpRequest request) {
         String url = getSelfURLhost(request);
 
         String requestUri = request.getRequestURI();
@@ -112,23 +89,23 @@ public class ServletUtils {
      * Returns the URL of the current host + current view.
      *
      * @param request
-     * 				HttpServletRequest object to be processed
+     * 				HttpRequest object to be processed
      *
      * @return current host + current view
      */
-    public static String getSelfURLNoQuery(HttpServletRequest request) {
-        return request.getRequestURL().toString();
+    public static String getSelfURLNoQuery(HttpRequest request) {
+        return request.getRequestURL();
     }
 
     /**
      * Returns the routed URL of the current host + current view.
      *
      * @param request
-     * 				HttpServletRequest object to be processed
+     * 				HttpRequest object to be processed
      *
      * @return the current routed url
      */
-    public static String getSelfRoutedURLNoQuery(HttpServletRequest request) {
+    public static String getSelfRoutedURLNoQuery(HttpRequest request) {
         String url = getSelfURLhost(request);
         String requestUri = request.getRequestURI();
         if (null != requestUri && !requestUri.isEmpty()) {
@@ -141,7 +118,7 @@ public class ServletUtils {
      * Redirect to location url
      *
      * @param response
-     * 				HttpServletResponse object to be used
+     * 				HttpResponse object to be used
      * @param location
      * 				target location url
      * @param parameters
@@ -152,9 +129,9 @@ public class ServletUtils {
      * @return string the target URL
      * @throws IOException
      *
-     * @see javax.servlet.http.HttpServletResponse#sendRedirect(String)
+     * @see HttpResponse#sendRedirect(String)
      */
-    public static String sendRedirect(HttpServletResponse response, String location, Map<String, String> parameters, Boolean stay) throws IOException {
+    public static String sendRedirect(HttpResponse response, String location, Map<String, String> parameters, Boolean stay) throws IOException {
         String target = location;
 
         if (!parameters.isEmpty()) {
@@ -184,7 +161,7 @@ public class ServletUtils {
      * Redirect to location url
      *
      * @param response
-     * 				HttpServletResponse object to be used
+     * 				HttpResponse object to be used
      * @param location
      * 				target location url
      * @param parameters
@@ -192,9 +169,9 @@ public class ServletUtils {
 	 *
      * @throws IOException
      *
-     * @see javax.servlet.http.HttpServletResponse#sendRedirect(String)
+     * @see HttpResponse#sendRedirect(String)
      */
-    public static void sendRedirect(HttpServletResponse response, String location, Map<String, String> parameters) throws IOException {
+    public static void sendRedirect(HttpResponse response, String location, Map<String, String> parameters) throws IOException {
     	sendRedirect(response, location, parameters, false);
     }
     	
@@ -202,15 +179,15 @@ public class ServletUtils {
      * Redirect to location url
      *
      * @param response
-     * 				HttpServletResponse object to be used
+     * 				HttpResponse object to be used
      * @param location
      * 				target location url
      *
      * @throws IOException
      *
-     * @see HttpServletResponse#sendRedirect(String)
+     * @see HttpResponse#sendRedirect(String)
      */
-    public static void sendRedirect(HttpServletResponse response, String location) throws IOException {
+    public static void sendRedirect(HttpResponse response, String location) throws IOException {
         Map<String, String> parameters  =new HashMap<String, String>();
         sendRedirect(response, location, parameters);
     }

--- a/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -1,7 +1,5 @@
 package com.onelogin.saml2.test;
 
-
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -23,12 +21,9 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
+import com.onelogin.saml2.http.HttpRequest;
+import com.onelogin.saml2.http.HttpResponse;
 import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
@@ -104,10 +99,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testConstructorWithReqRes() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Auth auth = new Auth(request, response);
 		assertTrue(auth.getSettings() != null);
@@ -130,10 +123,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testConstructorWithFilenameReqRes() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Auth auth = new Auth("config/config.min.properties", request, response);
 		assertTrue(auth.getSettings() != null);
@@ -156,10 +147,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testConstructorWithSettingsReqRes() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -183,13 +172,11 @@ public class AuthTest {
 		expectedEx.expect(SettingsException.class);
 		expectedEx.expectMessage("Invalid settings: sp_entityId_not_found, sp_acs_not_found, sp_cert_not_found_and_required, contact_not_enought_data, organization_not_enought_data, idp_cert_or_fingerprint_not_found_and_required, idp_cert_not_found_and_required");
 		
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.sperrors.properties").build();
-		Auth auth = new Auth(settings, request, response);
+		new Auth(settings, request, response);
 	}
 
 	/**
@@ -252,10 +239,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testIsDebugActive() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpResponse response = mock(HttpResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		settings.setDebug(false);
@@ -280,10 +265,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetSSOurl() throws URISyntaxException, IOException, SettingsException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
@@ -303,10 +286,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetSLOurl() throws URISyntaxException, IOException, SettingsException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
@@ -327,10 +308,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetSLOResponseUrl() throws URISyntaxException, IOException, SettingsException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.all.properties").build();
 
@@ -350,10 +329,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetSLOResponseUrlNull() throws URISyntaxException, IOException, SettingsException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
@@ -370,9 +347,9 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessNoResponse() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -402,12 +379,12 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessResponse() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -418,7 +395,7 @@ public class AuthTest {
 		assertTrue(auth.getAttributes().isEmpty());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 
 		HashMap<String, List<String>> expectedAttributes = new HashMap<String, List<String>>();
@@ -461,9 +438,9 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLONoMessage() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -491,14 +468,12 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestKeepSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLRequest", new String[]{samlRequestEncoded}));		
+		when(request.getParameter("SAMLRequest")).thenReturn(samlRequestEncoded);
 		
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -506,7 +481,7 @@ public class AuthTest {
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO(true, null);
 		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLResponse=(.)*"));
-		verify(session, times(0)).invalidate();
+		verify(request, times(0)).invalidateSession();
 		assertTrue(auth.getErrors().isEmpty());
 	}
 
@@ -520,21 +495,19 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestRemoveSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLRequest", new String[]{samlRequestEncoded}));		
+		when(request.getParameter("SAMLRequest")).thenReturn(samlRequestEncoded);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();
 		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLResponse=(.)*"));
-		verify(session, times(1)).invalidate();
+		verify(request, times(1)).invalidateSession();
 		assertTrue(auth.getErrors().isEmpty());
 	}
 
@@ -548,19 +521,13 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestSignRes() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 		String relayState = "http://localhost:8080/expected.jsp";
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
-		Map<String, String[]> paramsAsArray = new HashMap<>();
-		paramsAsArray.put("SAMLRequest", new String[]{samlRequestEncoded});
-		paramsAsArray.put("RelayState", new String[]{relayState});
-		when(request.getParameterMap()).thenReturn(paramsAsArray);
+		when(request.getParameter("SAMLRequest")).thenReturn(samlRequestEncoded);
 		when(request.getParameter("RelayState")).thenReturn(relayState);
-		
 		
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.all.properties").build();
 		settings.setWantMessagesSigned(false);
@@ -570,7 +537,7 @@ public class AuthTest {
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();
 		verify(response).sendRedirect(matches("http:\\/\\/idp.example.com\\/simplesaml\\/saml2\\/idp\\/SingleLogoutServiceResponse.php\\?SAMLResponse=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha512&Signature=(.)*"));
-		verify(session, times(1)).invalidate();
+		verify(request, times(1)).invalidateSession();
 		assertTrue(auth.getErrors().isEmpty());
 	}
 	
@@ -584,21 +551,19 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestInvalid() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/sls.jsp"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/sls.jsp");
 
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLRequest", new String[]{samlRequestEncoded}));
+		when(request.getParameter("SAMLRequest")).thenReturn(samlRequestEncoded);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		settings.setStrict(true);
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();		
-		verify(session, times(0)).invalidate();
+		verify(request, times(0)).invalidateSession();
 		assertFalse(auth.getErrors().isEmpty());
 		assertTrue(auth.getErrors().contains("invalid_logout_request"));
 		assertThat(auth.getLastErrorReason(), containsString("The LogoutRequest was received at"));
@@ -614,20 +579,18 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseKeepSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 
 		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO(true, null);
-		verify(session, times(0)).invalidate();
+		verify(request, times(0)).invalidateSession();
 		assertTrue(auth.getErrors().isEmpty());
 	}
 
@@ -641,20 +604,18 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseRemoveSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 
 		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();
-		verify(session, times(1)).invalidate();
+		verify(request, times(1)).invalidateSession();
 		assertTrue(auth.getErrors().isEmpty());
 	}
 
@@ -668,21 +629,19 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseWrongRequestId() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 
 		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		settings.setStrict(true);
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO(false, "wrong_request_id");
-		verify(session, times(0)).invalidate();
+		verify(request, times(0)).invalidateSession();
 		assertTrue(auth.getErrors().contains("invalid_logout_response"));
 		assertEquals("The InResponseTo of the Logout Response: ONELOGIN_21584ccdfaca36a145ae990442dcd96bfe60151e, does not match the ID of the Logout request sent by the SP: wrong_request_id", auth.getLastErrorReason());
 	}
@@ -697,20 +656,18 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseStatusResponder() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpSession session = mock(HttpSession.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
-		when(request.getSession()).thenReturn(session);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 
 		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/invalids/status_code_responder.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Auth auth = new Auth(settings, request, response);
 		assertFalse(auth.isAuthenticated());
 		assertTrue(auth.getErrors().isEmpty());
 		auth.processSLO();
-		verify(session, times(0)).invalidate();
+		verify(request, times(0)).invalidateSession();
 		assertFalse(auth.getErrors().isEmpty());
 		assertTrue(auth.getErrors().contains("logout_not_success"));
 	}
@@ -726,11 +683,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testIsAuthenticated() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response4.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -745,7 +702,7 @@ public class AuthTest {
 		assertEquals("SAML Response must contain 1 Assertion.", auth.getLastErrorReason());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 		assertFalse(auth2.isAuthenticated());
 		assertTrue(auth2.getErrors().isEmpty());
@@ -758,7 +715,7 @@ public class AuthTest {
 		assertThat(auth2.getLastErrorReason(), containsString("Invalid issuer in the Assertion/Response"));
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth3 = new Auth(settings, request, response);
 		assertFalse(auth3.isAuthenticated());
 		assertTrue(auth3.getErrors().isEmpty());
@@ -778,11 +735,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetNameID() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -792,7 +749,7 @@ public class AuthTest {
 		assertNull(auth.getNameId());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 		assertNull(auth2.getNameId());
 		auth2.processResponse();
@@ -800,8 +757,8 @@ public class AuthTest {
 		assertEquals("492882615acf31c8096b627245d76ae53036c090", auth2.getNameId());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("https://pitbulk.no-ip.org/newonelogin/demo1/index.php?acs"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("https://pitbulk.no-ip.org/newonelogin/demo1/index.php?acs");
 		settings.setStrict(false);
 		Auth auth3 = new Auth(settings, request, response);
 		assertNull(auth3.getNameId());
@@ -820,11 +777,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetNameIdFormat() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -834,7 +791,7 @@ public class AuthTest {
 		assertNull(auth.getNameIdFormat());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 		assertNull(auth2.getNameIdFormat());
 		auth2.processResponse();
@@ -842,8 +799,8 @@ public class AuthTest {
 		assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", auth2.getNameIdFormat());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("https://pitbulk.no-ip.org/newonelogin/demo1/index.php?acs"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("https://pitbulk.no-ip.org/newonelogin/demo1/index.php?acs");
 		settings.setStrict(false);
 		Auth auth3 = new Auth(settings, request, response);
 		assertNull(auth3.getNameIdFormat());
@@ -864,12 +821,12 @@ public class AuthTest {
 		expectedEx.expect(SettingsException.class);
 		expectedEx.expectMessage("Invalid settings: idp_cert_not_found_and_required");
 
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.mywithnocert.properties").build();
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("https://pitbulk.no-ip.org/newonelogin/demo1/index.php?acs"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("https://pitbulk.no-ip.org/newonelogin/demo1/index.php?acs");
 		settings.setStrict(false);
 		Auth auth = new Auth(settings, request, response);
 		assertNull(auth.getNameId());
@@ -890,11 +847,11 @@ public class AuthTest {
 		expectedEx.expect(ValidationError.class);
 		expectedEx.expectMessage("SAML Response could not be processed");
 
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/invalids/wrapped_response_2.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -912,11 +869,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetSessionIndex() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -926,7 +883,7 @@ public class AuthTest {
 		assertNull(auth.getSessionIndex());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 		assertNull(auth2.getSessionIndex());
 		auth2.processResponse();
@@ -936,11 +893,11 @@ public class AuthTest {
 
 	@Test
 	public void testGetAssertionDetails() throws Exception {
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -959,11 +916,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetSessionExpiration() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/acs.jsp"));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
+		when(request.getRequestURL()).thenReturn("http://localhost:8080/java-saml-jspsample/acs.jsp");
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -973,7 +930,7 @@ public class AuthTest {
 		assertNull(auth.getSessionExpiration());
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 		assertNull(auth2.getSessionExpiration());
 		auth2.processResponse();
@@ -994,8 +951,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLogin() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1022,8 +979,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLoginWithRelayState() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1051,8 +1008,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLoginWithoutRelayState() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");
@@ -1082,8 +1039,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLoginStay() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");
@@ -1119,8 +1076,8 @@ public class AuthTest {
 		expectedEx.expect(SettingsException.class);
 		expectedEx.expectMessage("Invalid settings: sp_cert_not_found_and_required");
 
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1147,8 +1104,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLoginSigned() throws IOException, SettingsException, URISyntaxException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1181,8 +1138,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLogout() throws IOException, SettingsException, XMLEntityException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1210,8 +1167,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLogoutWithRelayState() throws IOException, SettingsException, XMLEntityException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1240,8 +1197,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLogoutWithoutRelayState() throws IOException, SettingsException, XMLEntityException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");
@@ -1272,8 +1229,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLogoutStay() throws IOException, SettingsException, XMLEntityException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1309,8 +1266,8 @@ public class AuthTest {
 		expectedEx.expect(SettingsException.class);
 		expectedEx.expectMessage("Invalid settings: sp_cert_not_found_and_required");
 
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1337,8 +1294,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testLogoutSigned() throws IOException, SettingsException, XMLEntityException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		when(request.getScheme()).thenReturn("http");
 		when(request.getServerPort()).thenReturn(8080);
 		when(request.getServerName()).thenReturn("localhost");		
@@ -1689,8 +1646,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastAuthNRequest() throws IOException, SettingsException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
@@ -1712,8 +1669,8 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutRequestSent() throws IOException, SettingsException, XMLEntityException, Error {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
@@ -1732,11 +1689,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutRequestReceived() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("/"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("/");
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLRequest", new String[]{samlRequestEncoded}));
+		when(request.getParameter("SAMLRequest")).thenReturn(samlRequestEncoded);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -1755,11 +1712,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastSAMLResponse() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("/"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("/");
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);
@@ -1768,7 +1725,7 @@ public class AuthTest {
 		assertThat(samlResponseXML, containsString("<samlp:Response"));
 		
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 		Auth auth2 = new Auth(settings, request, response);
 		auth2.processResponse();
 		samlResponseXML =  auth2.getLastResponseXML();
@@ -1786,11 +1743,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutResponseSent() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("http://stuff.com/endpoints/endpoints/sls.php");
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLRequest", new String[]{samlRequestEncoded}));
+		when(request.getParameter("SAMLRequest")).thenReturn(samlRequestEncoded);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		settings.setStrict(false);
@@ -1810,11 +1767,11 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutResponseReceived() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		HttpServletResponse response = mock(HttpServletResponse.class);
-		when(request.getRequestURL()).thenReturn(new StringBuffer("/"));
+		HttpRequest request = mock(HttpRequest.class);
+		HttpResponse response = mock(HttpResponse.class);
+		when(request.getRequestURL()).thenReturn("/");
 		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response.xml.base64");
-		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
+		when(request.getParameter("SAMLResponse")).thenReturn(samlResponseEncoded);
 
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
 		Auth auth = new Auth(settings, request, response);

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -8,6 +8,7 @@ import com.onelogin.saml2.http.HttpRequest;
 import com.onelogin.saml2.model.SamlResponseStatus;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
+import com.onelogin.saml2.test.http.MockHttpRequest;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
 
@@ -2676,7 +2677,6 @@ public class AuthnResponseTest {
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlResponseEncoded) {
-		return new HttpRequest(requestURL).addParameter("SAMLResponse", samlResponseEncoded);
+		return new MockHttpRequest(requestURL).addParameter("SAMLResponse", samlResponseEncoded);
 	}
 }
-

--- a/core/src/test/java/com/onelogin/saml2/test/http/MockHttpRequest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/http/MockHttpRequest.java
@@ -1,0 +1,191 @@
+package com.onelogin.saml2.test.http;
+
+import com.onelogin.saml2.http.HttpRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import java.util.*;
+
+import static com.onelogin.saml2.util.Preconditions.checkNotNull;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * Mock HttpRequest implementation for unit testing
+ *
+ * @since 2.2.0
+ */
+public class MockHttpRequest extends HttpRequest {
+
+    public static final Map<String, List<String>> EMPTY_PARAMETERS = Collections.<String, List<String>>emptyMap();
+
+    private final String requestURL;
+    private final Map<String, List<String>> parameters;
+    private final String queryString;
+
+    /**
+     * Creates a new HttpRequest.
+     *
+     * @param requestURL the request URL (up to but not including query parameters)
+     * @throws NullPointerException if requestURL is null
+     * @deprecated Not providing a queryString can cause HTTP Redirect binding to fail.
+     */
+    @Deprecated
+    public MockHttpRequest(String requestURL) {
+        this(requestURL, EMPTY_PARAMETERS);
+    }
+
+    /**
+     * Creates a new HttpRequest.
+     *
+     * @param requestURL  the request URL (up to but not including query parameters)
+     * @param queryString string that is contained in the request URL after the path
+     */
+    public MockHttpRequest(String requestURL, String queryString) {
+        this(requestURL, EMPTY_PARAMETERS, queryString);
+    }
+
+    /**
+     * Creates a new HttpRequest.
+     *
+     * @param requestURL  the request URL (up to but not including query parameters)
+     * @param parameters the request query parameters
+     * @throws NullPointerException if any of the parameters is null
+     * @deprecated Not providing a queryString can cause HTTP Redirect binding to fail.
+     */
+    @Deprecated
+    public MockHttpRequest(String requestURL, Map<String, List<String>> parameters) {
+        this(requestURL, parameters, null);
+    }
+
+    /**
+     * Creates a new HttpRequest.
+     *
+     * @param requestURL  the request URL (up to but not including query parameters)
+     * @param parameters the request query parameters
+     * @param queryString string that is contained in the request URL after the path
+     * @throws NullPointerException if any of the parameters is null
+     */
+    public MockHttpRequest(String requestURL, Map<String, List<String>> parameters, String queryString) {
+        this.requestURL = checkNotNull(requestURL, "requestURL");
+        this.parameters = unmodifiableCopyOf(checkNotNull(parameters, "queryParams"));
+        this.queryString = StringUtils.trimToEmpty(queryString);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public String getScheme() {
+        return "http";
+    }
+
+    @Override
+    public String getServerName() {
+        return "localhost";
+    }
+
+    @Override
+    public int getServerPort() {
+        return 80;
+    }
+
+    @Override
+    public String getQueryString() {
+        return queryString;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return requestURL;
+    }
+
+    /**
+     * @param name  the query parameter name
+     * @param value the query parameter value
+     * @return a new HttpRequest with the given query parameter added
+     * @throws NullPointerException if any of the parameters is null
+     */
+    public MockHttpRequest addParameter(String name, String value) {
+        checkNotNull(name, "name");
+        checkNotNull(value, "value");
+
+        final List<String> oldValues = parameters.containsKey(name) ? parameters.get(name) : new ArrayList<String>();
+        final List<String> newValues = new ArrayList<>(oldValues);
+        newValues.add(value);
+        final Map<String, List<String>> params = new HashMap<>(parameters);
+        params.put(name, newValues);
+
+        return new MockHttpRequest(requestURL, params, queryString);
+    }
+
+    /**
+     * @param name  the query parameter name
+     * @return a new HttpRequest with the given query parameter removed
+     * @throws NullPointerException if any of the parameters is null
+     */
+    public MockHttpRequest removeParameter(String name) {
+        checkNotNull(name, "name");
+
+        final Map<String, List<String>> params = new HashMap<>(parameters);
+        params.remove(name);
+
+        return new MockHttpRequest(requestURL, params, queryString);
+    }
+
+    @Override
+    public String getRequestURL() {
+        return requestURL;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        final List<String> values = parameters.get(name);
+        return (values == null || values.isEmpty()) ? null : values.get(0);
+    }
+
+    @Override
+    public void invalidateSession() {
+        // Nothing to do
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MockHttpRequest that = (MockHttpRequest) o;
+        return Objects.equals(requestURL, that.requestURL) &&
+                Objects.equals(parameters, that.parameters) &&
+                Objects.equals(queryString, that.queryString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(requestURL, parameters, queryString);
+    }
+
+    @Override
+    public String toString() {
+        return "MockHttpRequest{" +
+                "requestURL='" + requestURL + '\'' +
+                ", parameters=" + parameters +
+                ", queryString=" + queryString +
+                '}';
+    }
+
+    private static Map<String, List<String>> unmodifiableCopyOf(Map<String, List<String>> orig) {
+        Map<String, List<String>> copy = new HashMap<>();
+        for (Map.Entry<String, List<String>> entry : orig.entrySet()) {
+            copy.put(entry.getKey(), unmodifiableList(new ArrayList<>(entry.getValue())));
+        }
+
+        return unmodifiableMap(copy);
+    }
+}

--- a/core/src/test/java/com/onelogin/saml2/test/http/MockHttpRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/http/MockHttpRequestTest.java
@@ -1,4 +1,4 @@
-package com.onelogin.saml2.http;
+package com.onelogin.saml2.test.http;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -6,10 +6,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,15 +17,13 @@ import org.junit.Test;
 import com.onelogin.saml2.test.NaiveUrlEncoder;
 import com.onelogin.saml2.util.Util;
 
-public class HttpRequestTest {
+public class MockHttpRequestTest {
     @Test
     public void testConstructorWithNoQueryParams() throws Exception {
         final String url = "url";
 
-        final HttpRequest request = new HttpRequest(url);
+        final MockHttpRequest request = new MockHttpRequest(url);
         assertThat(request.getRequestURL(), equalTo(url));
-        assertThat(request.getParameters(), equalTo(Collections.<String, List<String>>emptyMap()));
-        assertThat(request.getParameters("x"), equalTo(Collections.<String>emptyList()));
         assertThat(request.getParameter("x"), nullValue());
     }
 
@@ -41,10 +37,8 @@ public class HttpRequestTest {
         final List<String> values = Arrays.asList(value1, value2);
         final Map<String, List<String>> parametersMap = singletonMap(name, values);
 
-        final HttpRequest request = new HttpRequest(url, parametersMap);
+        final MockHttpRequest request = new MockHttpRequest(url, parametersMap);
         assertThat(request.getRequestURL(), equalTo(url));
-        assertThat(request.getParameters(), equalTo(parametersMap));
-        assertThat(request.getParameters(name), equalTo(values));
         assertThat(request.getParameter(name), equalTo(value1));
     }
 
@@ -54,14 +48,9 @@ public class HttpRequestTest {
         final String name = "name";
         final String value = "value";
 
-        final HttpRequest request = new HttpRequest(url).addParameter(name, value);
+        final MockHttpRequest request = new MockHttpRequest(url).addParameter(name, value);
         assertThat(request.getRequestURL(), equalTo(url));
-        assertThat(request.getParameters(), equalTo(singletonMap(name, singletonList(value))));
-        assertThat(request.getParameters(name), equalTo(singletonList(value)));
         assertThat(request.getParameter(name), equalTo(value));
-
-        final HttpRequest request2 = request.addParameter(name, value);
-        assertThat(request2.getParameters(name), equalTo(Arrays.asList(value, value)));
     }
 
     @Test
@@ -70,16 +59,12 @@ public class HttpRequestTest {
         final String name = "name";
         final String value = "value";
 
-        HttpRequest request = new HttpRequest(url).addParameter(name, value);
+        MockHttpRequest request = new MockHttpRequest(url).addParameter(name, value);
         assertThat(request.getRequestURL(), equalTo(url));
-        assertThat(request.getParameters(), equalTo(singletonMap(name, singletonList(value))));
-        assertThat(request.getParameters(name), equalTo(singletonList(value)));
         assertThat(request.getParameter(name), equalTo(value));
 
         request = request.removeParameter(name);
         assertThat(request.getRequestURL(), equalTo(url));
-        assertTrue(request.getParameters().isEmpty());
-        assertTrue(request.getParameters(name).isEmpty());
         assertNull(request.getParameter(name));
     }
 
@@ -91,10 +76,10 @@ public class HttpRequestTest {
         final String addedName = "added";
         final String addedValue = "added#value!";
 
-        final List<String> values = Arrays.asList(value1);
+        final List<String> values = singletonList(value1);
         final Map<String, List<String>> parametersMap = singletonMap(name, values);
 
-        final HttpRequest request = new HttpRequest(url, parametersMap).addParameter(addedName, addedValue);
+        final MockHttpRequest request = new MockHttpRequest(url, parametersMap).addParameter(addedName, addedValue);
 
         assertThat(request.getEncodedParameter(name), equalTo(Util.urlEncoder(value1)));
         assertThat(request.getEncodedParameter(addedName), equalTo(Util.urlEncoder(addedValue)));
@@ -108,10 +93,10 @@ public class HttpRequestTest {
         final String urlValue1 = "onUrl1";
         final String queryString = name + "=" + urlValue1;
 
-        final List<String> values = Arrays.asList(value1);
+        final List<String> values = singletonList(value1);
         final Map<String, List<String>> parametersMap = singletonMap(name, values);
 
-        final HttpRequest request = new HttpRequest(url, parametersMap, queryString);
+        final MockHttpRequest request = new MockHttpRequest(url, parametersMap, queryString);
 
         assertThat(request.getEncodedParameter(name), equalTo(urlValue1));
         assertThat(request.getParameter(name), equalTo(value1));
@@ -124,7 +109,7 @@ public class HttpRequestTest {
         String encodedValue1 = NaiveUrlEncoder.encode("do not alter!");
         final String queryString = name + "=" + encodedValue1;
 
-        final HttpRequest request = new HttpRequest(url, queryString);
+        final MockHttpRequest request = new MockHttpRequest(url, queryString);
 
         assertThat(request.getEncodedParameter(name), equalTo(encodedValue1));
     }
@@ -135,7 +120,7 @@ public class HttpRequestTest {
         final String queryString = "k1=v1&k2=v2&k3=v3";
 
         final Map<String, List<String>> parametersMap = new HashMap<>();
-        final HttpRequest request = new HttpRequest(url, parametersMap, queryString);
+        final MockHttpRequest request = new MockHttpRequest(url, parametersMap, queryString);
 
         assertThat(request.getEncodedParameter("k1"), equalTo("v1"));
         assertThat(request.getEncodedParameter("k2"), equalTo("v2"));
@@ -147,7 +132,7 @@ public class HttpRequestTest {
         final String url = "url";
         final String queryString = "first=&foo=bar#ignore";
 
-        final HttpRequest request = new HttpRequest(url, queryString);
+        final MockHttpRequest request = new MockHttpRequest(url, queryString);
 
         assertThat(request.getEncodedParameter("foo"), equalTo("bar"));
     }
@@ -157,7 +142,7 @@ public class HttpRequestTest {
         final String url = "url";
         final String foobar = "foo/bar!";
 
-        final HttpRequest request = new HttpRequest(url);
+        final MockHttpRequest request = new MockHttpRequest(url);
         assertThat(request.getEncodedParameter("missing", foobar), equalTo(Util.urlEncoder(foobar)));
     }
 
@@ -171,7 +156,7 @@ public class HttpRequestTest {
         final String queryString = name + "=" + encodedValue1;
 
         final Map<String, List<String>> parametersMap = new HashMap<>();
-        final HttpRequest request = new HttpRequest(url, parametersMap, queryString).addParameter(name, value1);
+        final MockHttpRequest request = new MockHttpRequest(url, parametersMap, queryString).addParameter(name, value1);
 
         assertThat(request.getEncodedParameter(name), equalTo(encodedValue1));
     }
@@ -184,12 +169,11 @@ public class HttpRequestTest {
         String encodedValue1 = NaiveUrlEncoder.encode(value1);
         final String queryString = name + "=" + encodedValue1;
 
-        final List<String> values = Arrays.asList(value1);
+        final List<String> values = singletonList(value1);
         final Map<String, List<String>> parametersMap = singletonMap(name, values);
 
-        final HttpRequest request = new HttpRequest(url, parametersMap, queryString).removeParameter(name);
+        final MockHttpRequest request = new MockHttpRequest(url, parametersMap, queryString).removeParameter(name);
 
         assertThat(request.getEncodedParameter(name), equalTo(encodedValue1));
     }
-
 }

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -18,6 +18,7 @@ import javax.xml.xpath.XPathExpressionException;
 
 import java.security.PrivateKey;
 
+import com.onelogin.saml2.test.http.MockHttpRequest;
 import org.w3c.dom.Document;
 import org.junit.Rule;
 import org.junit.Test;
@@ -646,7 +647,7 @@ public class LogoutRequestTest {
 		//This signature is based on the query string above
 		String signature = "cxDTcLRHhXJKGYcjZE2RRz5p7tVg/irNimq48KkJ0n10wiGwAmuzUByxEm4OHbetDrHGtxI5ygjrR0/HcrD8IkYyI5Ie4r5tJYkfdtpUrvOQ7khbBvP9GzEbZIrz7eH1ALdCDchORaRB/cs6v+OZbBj5uPTrN//wOhZl2k9H2xVW/SYy17jDoIKh/wvqtQ9FF+h2UxdUEhxeB/UUXOC6nVLMo+RGaamSviYkUE1Zu1tmalO+F6FivNQ31T/TkqzWz0KEjmnFs3eKbHakPVuUHpDQm7Gf2gBS1TXwVQsL7e2axtvv4RH5djlq1Z2WH2V+PwGOkIvLxf3igGUSR1A8bw==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL, queryString)
 				.addParameter("SAMLRequest", samlRequestEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -674,7 +675,7 @@ public class LogoutRequestTest {
 		//This signature is based on the query string above
 		String signatureNaiveEncoding = "Gj2mUq6RBPAPXI9VjDDlwAxueSEBlOfgpWKLpsQbqIp+2XPFtC/vPAZpuPjHCDNNnAI3WKZa4l8ijwQBTqQwKz88k9gTx6vcLxPl2L4SrWdLOokiGrIVYJ+0sK2hapHHMa7WzGiTgpeTuejHbD4ptneaRXl4nrJAEo0WJ/rNTSWbJpnb+ENtgBnsfkmj+6z1KFY70ruo7W/vme21Jg+4XNfBSGl6LLSjEnZHJG0ET80HKvJEZayv4BQGZ3MShcSMyab/w+rLfDvDRA5RcRxw+NHOXo/kxZ3qhpa6daOwG69+PiiWmusmB2gaSq6jy2L55zFks9a36Pt5l5fYA2dE4g==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL, queryString)
 				.addParameter("SAMLRequest", samlRequestEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -703,7 +704,7 @@ public class LogoutRequestTest {
 		String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 		String signature = "XCwCyI5cs7WhiJlB5ktSlWxSBxv+6q2xT3c8L7dLV6NQG9LHWhN7gf8qNsahSXfCzA0Ey9dp5BQ0EdRvAk2DIzKmJY6e3hvAIEp1zglHNjzkgcQmZCcrkK9Czi2Y1WkjOwR/WgUTUWsGJAVqVvlRZuS3zk3nxMrLH6f7toyvuJc=";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL)
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL)
 						.addParameter("SAMLRequest", samlRequestEncoded)
 						.addParameter("RelayState", relayState)
 						.addParameter("SigAlg", sigAlg)
@@ -821,6 +822,6 @@ public class LogoutRequestTest {
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlRequestEncoded) {
-		return new HttpRequest(requestURL).addParameter("SAMLRequest", samlRequestEncoded);
+		return new MockHttpRequest(requestURL).addParameter("SAMLRequest", samlRequestEncoded);
 	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -14,6 +14,7 @@ import java.net.URISyntaxException;
 
 import javax.xml.xpath.XPathExpressionException;
 
+import com.onelogin.saml2.test.http.MockHttpRequest;
 import org.junit.Test;
 
 import com.onelogin.saml2.exception.Error;
@@ -40,7 +41,7 @@ public class LogoutResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		final String logoutResponseString = Util.getFileAsString("data/logout_responses/logout_response.xml");
 		final String requestURL = "/";
-		HttpRequest httpRequest = new HttpRequest(requestURL);
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL);
 
 		LogoutResponse logoutResponseBuilder = new LogoutResponse(settings, httpRequest) {
 			@Override
@@ -136,7 +137,7 @@ public class LogoutResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		final String requestURL = "/";
-		HttpRequest httpRequest = new HttpRequest(requestURL);
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL);
 
 		LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertFalse(logoutResponse.isValid());
@@ -256,7 +257,7 @@ public class LogoutResponseTest {
 		assertFalse(logoutResponse.isValid());
 		assertEquals("SAML Logout Response is not loaded", logoutResponse.getError());
 
-		httpRequest = new HttpRequest(requestURL);
+		httpRequest = new MockHttpRequest(requestURL);
 		logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertFalse(logoutResponse.isValid());
 		assertEquals("SAML Logout Response is not loaded", logoutResponse.getError());		
@@ -439,7 +440,7 @@ public class LogoutResponseTest {
 		//This signature is based on the query string above
 		String signature = "czxEy2WDRZS1U4b2PQFpE4KRhRs8jt5bBKdTFx5oIXpte6qtm0Lk/5lzw/2S6Y1NJpj5DJvSLJvylgNE+RYfJR1GX0zQplm2dZYtlo7CZUyfS3JCLsWviEtPXaon+8Z0lQQkPt4yxCf9v8Qd0pvxHglTUCK/sU0NXnZQdpSxxfsaNCcjQf5gTg/gj8oI7xdrnamBPFtsaH6tAirkjGMoYS4Otju3mcrdcNBIHG40wrffUDnE83Jw4AOFCp8Vsf0zPTQOQsxS4HF4VS78OvGn7jLi2MdabeAQcK5+tP3mUB4vO8AAt8QbkEEiWQbcvA9i1Ezma92CdNYgaf4B3JYpPA==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL, queryString)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -467,7 +468,7 @@ public class LogoutResponseTest {
 		//This signature is based on the query string above
 		String signature = "eSoTB+0GA/HfncASEFk7ONHbB3+9YrOBgK9xUyRoCDY97oXw49JYoXOL07kHrVvbngKmKFNx5fnYtDaL8WCe5LfRRgjJz1LLacriHn2ggeMmY/fTaXPoy2zQW0Fv1H362QXicTWQXgWFS5cJAIcBa2I7TLgNwXsMgjdBF2hyacW0IwfkAceGiBwDDTy6XIBAZk2Ff7w5lbZh+fa5JLNKrbvoveJk2NS3KK6INYO7UW5hukWz2cpzbHsx9lfxUJi8/ZCwUtFWZ4rdXVN+Qiw5y8S2eE2BIEfFmz7IfvrMRXa2la/rXFQfmteQo+N1sO3K1YZyoT/aA3k36glXvnj3kw==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL, queryString)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -499,7 +500,7 @@ public class LogoutResponseTest {
 		String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 		String signature = "vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA=";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL)
+		MockHttpRequest httpRequest = new MockHttpRequest(requestURL)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -593,6 +594,6 @@ public class LogoutResponseTest {
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlResponseEncoded) {
-		return new HttpRequest(requestURL).addParameter("SAMLResponse", samlResponseEncoded);
+		return new MockHttpRequest(requestURL).addParameter("SAMLResponse", samlResponseEncoded);
 	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/servlet/ServletUtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/servlet/ServletUtilsTest.java
@@ -1,10 +1,7 @@
 package com.onelogin.saml2.test.servlet;
 
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,14 +10,11 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.onelogin.saml2.http.HttpResponse;
 import org.junit.Test;
 
 import com.onelogin.saml2.http.HttpRequest;
 import com.onelogin.saml2.servlet.ServletUtils;
-import com.onelogin.saml2.test.NaiveUrlEncoder;
 
 public class ServletUtilsTest {
     /**
@@ -33,17 +27,13 @@ public class ServletUtilsTest {
      */
     @Test
     public void testSendRedirectRelative() throws IOException {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
-        HttpServletResponse response_1 = mock(HttpServletResponse.class);
+        HttpResponse response_1 = mock(HttpResponse.class);
         // mock the getRequestURI() response
-        when(request_1.getRequestURI()).thenReturn("/initial.jsp");
         ServletUtils.sendRedirect(response_1, "http://example.com/expectedurl.jsp");
         // verify if a sendRedirect() was performed with the expected value
         verify(response_1).sendRedirect("http://example.com/expectedurl.jsp");
 
-        HttpServletRequest request_2 = mock(HttpServletRequest.class);
-        HttpServletResponse response_2 = mock(HttpServletResponse.class);
-        when(request_2.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_2 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_2, "/expectedurl.jsp");
         verify(response_2).sendRedirect("/expectedurl.jsp");
     }
@@ -58,15 +48,11 @@ public class ServletUtilsTest {
      */
     @Test
     public void testSendRedirectProtocol() throws IOException {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
-        HttpServletResponse response_1 = mock(HttpServletResponse.class);
-        when(request_1.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_1 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_1, "http://example.com/expectedurl.jsp");
         verify(response_1).sendRedirect("http://example.com/expectedurl.jsp");
 
-        HttpServletRequest request_2 = mock(HttpServletRequest.class);
-        HttpServletResponse response_2 = mock(HttpServletResponse.class);
-        when(request_2.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_2 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_2, "https://example.com/expectedurl.jsp");
         verify(response_2).sendRedirect("https://example.com/expectedurl.jsp");
     }
@@ -82,38 +68,28 @@ public class ServletUtilsTest {
     @Test
     public void testSendRedirectParams() throws IOException {
         Map<String, String> parameters = new HashMap<String, String>();
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
-        HttpServletResponse response_1 = mock(HttpServletResponse.class);
-        when(request_1.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_1 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_1, "http://example.com/expectedurl.jsp", parameters);
         verify(response_1).sendRedirect("http://example.com/expectedurl.jsp");
 
         parameters.put("test", "true");
-        HttpServletRequest request_2 = mock(HttpServletRequest.class);
-        HttpServletResponse response_2 = mock(HttpServletResponse.class);
-        when(request_2.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_2 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_2, "http://example.com/expectedurl.jsp", parameters);
         verify(response_2).sendRedirect("http://example.com/expectedurl.jsp?test=true");
 
         parameters.put("value1", "a");
-        HttpServletRequest request_3 = mock(HttpServletRequest.class);
-        HttpServletResponse response_3 = mock(HttpServletResponse.class);
-        when(request_3.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_3 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_3, "http://example.com/expectedurl.jsp", parameters);
         verify(response_3).sendRedirect("http://example.com/expectedurl.jsp?test=true&value1=a");
 
         parameters.put("novalue", "");
-        HttpServletRequest request_4 = mock(HttpServletRequest.class);
-        HttpServletResponse response_4 = mock(HttpServletResponse.class);
-        when(request_4.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_4 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_4, "http://example.com/expectedurl.jsp", parameters);
         verify(response_4).sendRedirect("http://example.com/expectedurl.jsp?novalue&test=true&value1=a");
 
         Map<String, String> parameters_2 = new HashMap<String, String>();
         parameters_2.put("novalue", "");
-        HttpServletRequest request_5 = mock(HttpServletRequest.class);
-        HttpServletResponse response_5 = mock(HttpServletResponse.class);
-        when(request_5.getRequestURI()).thenReturn("/initial.jsp");
+        HttpResponse response_5 = mock(HttpResponse.class);
         ServletUtils.sendRedirect(response_5, "http://example.com/expectedurl.jsp", parameters_2);
         verify(response_5).sendRedirect("http://example.com/expectedurl.jsp?novalue");
     }
@@ -128,7 +104,7 @@ public class ServletUtilsTest {
      */
     @Test
     public void testSendRedirectStay() throws IOException {
-        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpResponse response = mock(HttpResponse.class);
         Map<String, String> parameters = new HashMap<String, String>();
         
         String url = ServletUtils.sendRedirect(response, "http://example.com/expectedurl.jsp", parameters, true);
@@ -145,7 +121,7 @@ public class ServletUtilsTest {
      */
     @Test
     public void testGetSelfURLhost() {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
+        HttpRequest request_1 = mock(HttpRequest.class);
         when(request_1.getScheme()).thenReturn("http");
         when(request_1.getServerName()).thenReturn("example.com");
         when(request_1.getServerPort()).thenReturn(80);
@@ -169,7 +145,7 @@ public class ServletUtilsTest {
      */
     @Test
     public void testGetSelfHost() {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
+        HttpRequest request_1 = mock(HttpRequest.class);
         when(request_1.getServerName()).thenReturn("example.com");
         assertEquals("example.com", ServletUtils.getSelfHost(request_1));
     }
@@ -181,7 +157,7 @@ public class ServletUtilsTest {
      */
     @Test
     public void testIsHTTPS() {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
+        HttpRequest request_1 = mock(HttpRequest.class);
         when(request_1.isSecure()).thenReturn(false);
         assertEquals(false, ServletUtils.isHTTPS(request_1));
 
@@ -196,7 +172,7 @@ public class ServletUtilsTest {
      */
     @Test
     public void testGetSelfURL() {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
+        HttpRequest request_1 = mock(HttpRequest.class);
         when(request_1.getScheme()).thenReturn("http");
         when(request_1.getServerName()).thenReturn("example.com");
         when(request_1.getRequestURI()).thenReturn("/test");
@@ -212,7 +188,7 @@ public class ServletUtilsTest {
         when(request_1.getRequestURI()).thenReturn(null);
         assertEquals("http://example.com?novalue&test=true&value1=a", ServletUtils.getSelfURL(request_1));
 
-        HttpServletRequest request_2 = mock(HttpServletRequest.class);
+        HttpRequest request_2 = mock(HttpRequest.class);
         when(request_2.getScheme()).thenReturn("http");
         when(request_2.getServerName()).thenReturn("example.com");
         when(request_2.getRequestURI()).thenReturn("/test");
@@ -232,9 +208,8 @@ public class ServletUtilsTest {
      */
     @Test
     public void testGetSelfURLNoQuery() {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
-        StringBuffer url = new StringBuffer("http://example.com/test");
-        when(request_1.getRequestURL()).thenReturn(url);
+        HttpRequest request_1 = mock(HttpRequest.class);
+        when(request_1.getRequestURL()).thenReturn("http://example.com/test");
         assertEquals("http://example.com/test", ServletUtils.getSelfURLNoQuery(request_1));
     }
 
@@ -245,7 +220,7 @@ public class ServletUtilsTest {
      */
     @Test
     public void testGetSelfRoutedURLNoQuery() {
-        HttpServletRequest request_1 = mock(HttpServletRequest.class);
+        HttpRequest request_1 = mock(HttpRequest.class);
         when(request_1.getScheme()).thenReturn("http");
         when(request_1.getServerName()).thenReturn("example.com");
         when(request_1.getRequestURI()).thenReturn("/test");
@@ -258,28 +233,10 @@ public class ServletUtilsTest {
         assertEquals("http://example.com", ServletUtils.getSelfRoutedURLNoQuery(request_1));
     }
 
-    @Test
-    public void testMakeHttpRequest() throws Exception {
-        final String url = "http://localhost:1234/a/b";
-        final Map<String, String[]> paramAsArray = singletonMap("name", new String[]{"a"});
-
-        final HttpServletRequest servletRequest = mock(HttpServletRequest.class);
-        when(servletRequest.getRequestURL()).thenReturn(new StringBuffer(url));
-        when(servletRequest.getParameterMap()).thenReturn(paramAsArray);
-
-        final String barNaiveEncoded = NaiveUrlEncoder.encode("bar"); //must differ from normal url encode
-		when(servletRequest.getQueryString()).thenReturn("foo=" + barNaiveEncoded);
-
-        final HttpRequest httpRequest = ServletUtils.makeHttpRequest(servletRequest);
-        assertThat(httpRequest.getRequestURL(), equalTo(url));
-        assertThat(httpRequest.getParameters(), equalTo(singletonMap("name", singletonList("a"))));
-        assertThat(httpRequest.getEncodedParameter("foo"), equalTo(barNaiveEncoded));
-    }
-
 	@Test
 	public void sendRedirectToShouldHandleUrlsWithQueryParams() throws Exception {
 		// having
-		final HttpServletResponse response = mock(HttpServletResponse.class);
+		final HttpResponse response = mock(HttpResponse.class);
 
 		// when
 		ServletUtils.sendRedirect(response, "https://sso.connect.pingidentity.com/sso/idp/SSO.saml2?idpid=ffee-aabbb", singletonMap("SAMLRequest", "data"));

--- a/toolkit/src/main/java/com/onelogin/saml2/http/JavaxHttpRequest.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/http/JavaxHttpRequest.java
@@ -1,0 +1,66 @@
+package com.onelogin.saml2.http;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * {@link HttpRequest} implementation which wraps a standard
+ * {@link HttpServletRequest} for a JavaEE-style container.
+ *
+ * @since 2.2.0
+ */
+public class JavaxHttpRequest extends HttpRequest {
+
+    /**
+     * The underlying request object
+     */
+    private final HttpServletRequest request;
+
+    public JavaxHttpRequest(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return request.isSecure();
+    }
+
+    @Override
+    public String getScheme() {
+        return request.getScheme();
+    }
+
+    @Override
+    public String getServerName() {
+        return request.getServerName();
+    }
+
+    @Override
+    public int getServerPort() {
+        return request.getServerPort();
+    }
+
+    @Override
+    public String getQueryString() {
+        return request.getQueryString();
+    }
+
+    @Override
+    public String getRequestURI() {
+        return request.getRequestURI();
+    }
+
+    @Override
+    public String getRequestURL() {
+        return request.getRequestURL().toString();
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return request.getParameter(name);
+    }
+
+    @Override
+    public void invalidateSession() {
+        request.getSession().invalidate();
+    }
+}

--- a/toolkit/src/main/java/com/onelogin/saml2/http/JavaxHttpResponse.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/http/JavaxHttpResponse.java
@@ -1,0 +1,27 @@
+package com.onelogin.saml2.http;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * {@link HttpResponse} implementation which wraps a standard
+ * {@link HttpServletResponse} for a JavaEE-style container.
+ *
+ * @since 2.2.0
+ */
+public class JavaxHttpResponse extends HttpResponse {
+
+    /**
+     * The underlying response object
+     */
+    private final HttpServletResponse response;
+
+    public JavaxHttpResponse(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    @Override
+    public void sendRedirect(String target) throws IOException {
+        this.response.sendRedirect(target);
+    }
+}


### PR DESCRIPTION
The default Auth and ServletUtils classes were previously tied to the javax.servlet APIs, so couldn't be used in other frameworks (e.g. Play).

Instead, introduce abstract HttpRequest and HttpResponse classes which can be used as wrappers around different request and response objects depending on the framework (plus default javax implementations).

A nice result of this is that Auth and ServletUtils can move to the core module - the toolkit jar now contains *only* the javax.servlet wrappers.