### PR TITLE
Add HTTP-POST binding support for IdP SingleSignOnService

### DIFF
--- a/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
+++ b/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
@@ -58,7 +58,7 @@ onelogin.saml2.idp.single_sign_on_service.url =
 
 # SAML protocol binding to be used when returning the <Response>
 # message.  Onelogin Toolkit supports for this endpoint the
-# HTTP-Redirect binding only
+# HTTP-Redirect and HTTP-POST bindings
 onelogin.saml2.idp.single_sign_on_service.binding = urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect
 
 # SLO endpoint info of the IdP.

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -292,7 +292,11 @@ public class Auth {
 		if (!stay) {
 			LOGGER.debug("AuthNRequest sent to " + ssoUrl + " --> " + samlRequest);
 		}
-		return ServletUtils.sendRedirect(response, ssoUrl, parameters, stay);
+
+		if (Constants.BINDING_HTTP_POST.equals(settings.getIdpSingleSignOnServiceBinding()))
+			return ServletUtils.sendPost(response, ssoUrl, parameters, stay);
+		else // Anything else is assumed to be a redirect
+			return ServletUtils.sendRedirect(response, ssoUrl, parameters, stay);
 	}
 
 	/**

--- a/toolkit/src/main/java/com/onelogin/saml2/servlet/ServletUtils.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/servlet/ServletUtils.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.onelogin.saml2.http.HttpRequest;
@@ -178,6 +179,22 @@ public class ServletUtils {
         }
 
         return target;
+    }
+
+    public static String sendPost(HttpServletResponse response, String location, Map<String, String> parameters, Boolean stay) throws IOException {
+      StringBuilder html = new StringBuilder();
+      html.append("<html>\n<head>\n<title>SAML Post</title>\n</head>\n")
+          .append("<body onload=\"document.getElementById('theform').submit();\">\n")
+          .append("<form id=\"theform\" action=\"").append(location).append("\" method=\"post\">\n");
+      for (String name : parameters.keySet()) {
+        String value = parameters.get(name);
+        html.append("<input type=\"hidden\" name=\"").append(name).append("\" value=\"").append(StringEscapeUtils.escapeHtml4(value)).append("\"/>\n");
+      }
+      html.append("</form>\n</body>\n</html>");
+      if (!stay) {
+        response.getWriter().write(html.toString());
+      }
+      return html.toString();
     }
 
     /**


### PR DESCRIPTION
Created a simple self-submitting form to POST a SAMLRequest to the IdP when HTTP-POST binding is required.