### PR TITLE
Don't send keys in SP Metadata file that you don't want the IdP to use

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -303,7 +303,7 @@ public class Metadata {
 			byte[] encodedCert = cert.getEncoded();
 			String certString = new String(encoder.encode(encodedCert));
 
-			if (settings.getAuthnRequestsSigned() || settings.getLogoutRequestSigned()) {
+			if (settings.getAuthnRequestsSigned() || settings.getLogoutRequestSigned() || settings.getLogoutResponseSigned()) {
 				keyDescriptorXml.append("<md:KeyDescriptor use=\"signing\">");
 				keyDescriptorXml.append("<ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">");
 				keyDescriptorXml.append("<ds:X509Data>");

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -303,7 +303,7 @@ public class Metadata {
 			byte[] encodedCert = cert.getEncoded();
 			String certString = new String(encoder.encode(encodedCert));
 
-			if (settings.getAuthnRequestsSigned()) {
+			if (settings.getAuthnRequestsSigned() || settings.getLogoutRequestSigned()) {
 				keyDescriptorXml.append("<md:KeyDescriptor use=\"signing\">");
 				keyDescriptorXml.append("<ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">");
 				keyDescriptorXml.append("<ds:X509Data>");


### PR DESCRIPTION
Don't send the encryption key if you don't want assertions encrypted.  Don't send the signing key if you aren't going to sign your authnrequests.  The IdP will see these as indicators that you want the keys to be used (especially the encrypted assertions).