### PR TITLE
New onelogin.saml.properties that are useful for testing

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -288,13 +288,13 @@ public class SamlResponse {
 
 				validateSubjectConfirmation(responseInResponseTo);
 
-                if (settings.getWantAssertionsSigned() && !hasSignedAssertion) {
-                	throw new ValidationError("The Assertion of the Response is not signed and the SP requires it", ValidationError.NO_SIGNED_ASSERTION);
-                }
+				if (settings.getWantAssertionsSigned() && !hasSignedAssertion) {
+					throw new ValidationError("The Assertion of the Response is not signed and the SP requires it", ValidationError.NO_SIGNED_ASSERTION);
+				}
 
-                if (settings.getWantMessagesSigned() && !hasSignedResponse) {
-                	throw new ValidationError("The Message of the Response is not signed and the SP requires it", ValidationError.NO_SIGNED_MESSAGE);
-                }
+				if (settings.getWantMessagesSigned() && !hasSignedResponse) {
+					throw new ValidationError("The Message of the Response is not signed and the SP requires it", ValidationError.NO_SIGNED_MESSAGE);
+				}
 			}
 
 			if (signedElements.isEmpty() || (!hasSignedAssertion && !hasSignedResponse)) {
@@ -355,7 +355,7 @@ public class SamlResponse {
 						continue;
 					}
 
-					if (!recipient.getNodeValue().equals(currentUrl)) {
+					if (settings.isValidateRecipient() && !recipient.getNodeValue().equals(currentUrl)) {
 						validationIssues.add(new SubjectConfirmationIssue(i, "SubjectConfirmationData doesn't match a valid Recipient"));
 						continue;
 					}

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -73,6 +73,7 @@ public class Saml2Settings {
 	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
 	private boolean validateTimes = true;
 	private boolean validateAudience = true;
+	private boolean validateRecipient = true;
 
 	// Compress
 	private Boolean compressRequest = true;
@@ -703,6 +704,16 @@ public class Saml2Settings {
 	public void setValidateAudience(boolean validateAudience)
 	{
 		this.validateAudience = validateAudience;
+	}
+
+	public boolean isValidateRecipient()
+	{
+		return validateRecipient;
+	}
+
+	public void setValidateRecipient(boolean validateRecipient)
+	{
+		this.validateRecipient = validateRecipient;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -71,6 +71,8 @@ public class Saml2Settings {
 	private Boolean wantXMLValidation = true;
 	private String signatureAlgorithm = Constants.RSA_SHA1;
 	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
+	private boolean validateTimes = true;
+	private boolean validateAudience = true;
 
 	// Compress
 	private Boolean compressRequest = true;
@@ -681,6 +683,26 @@ public class Saml2Settings {
 
 	public boolean isRejectUnsolicitedResponsesWithInResponseTo() {
 		return rejectUnsolicitedResponsesWithInResponseTo;
+	}
+
+	public boolean isValidateTimes()
+	{
+		return validateTimes;
+	}
+
+	public void setValidateTimes(boolean validateTimes)
+	{
+		this.validateTimes = validateTimes;
+	}
+
+	public boolean isValidateAudience()
+	{
+		return validateAudience;
+	}
+
+	public void setValidateAudience(boolean validateAudience)
+	{
+		this.validateAudience = validateAudience;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -84,6 +84,8 @@ public class SettingsBuilder {
 	public final static String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
 	public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
 	public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO = "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
+	public final static String SECURITY_VALIDATE_TIMES = "onelogin.saml2.security.validateTimes";
+	public final static String SECURITY_VALIDATE_AUDIENCE = "onelogin.saml2.security.validateAudience";
 
 	// Compress
 	public final static String COMPRESS_REQUEST = "onelogin.saml2.compress.request";
@@ -299,6 +301,14 @@ public class SettingsBuilder {
 		if (rejectUnsolicitedResponsesWithInResponseTo != null) {
 			saml2Setting.setRejectUnsolicitedResponsesWithInResponseTo(rejectUnsolicitedResponsesWithInResponseTo);
 		}
+
+		Boolean validateTimes = loadBooleanProperty(SECURITY_VALIDATE_TIMES);
+		if (validateTimes != null)
+			saml2Setting.setValidateTimes(validateTimes);
+
+		Boolean validateAudience = loadBooleanProperty(SECURITY_VALIDATE_AUDIENCE);
+		if (validateAudience != null)
+			saml2Setting.setValidateAudience(validateAudience);
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -86,6 +86,7 @@ public class SettingsBuilder {
 	public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO = "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
 	public final static String SECURITY_VALIDATE_TIMES = "onelogin.saml2.security.validateTimes";
 	public final static String SECURITY_VALIDATE_AUDIENCE = "onelogin.saml2.security.validateAudience";
+	public final static String SECURITY_VALIDATE_RECIPIENT = "onelogin.saml2.security.validateRecipient";
 
 	// Compress
 	public final static String COMPRESS_REQUEST = "onelogin.saml2.compress.request";
@@ -309,6 +310,10 @@ public class SettingsBuilder {
 		Boolean validateAudience = loadBooleanProperty(SECURITY_VALIDATE_AUDIENCE);
 		if (validateAudience != null)
 			saml2Setting.setValidateAudience(validateAudience);
+
+		Boolean validateRecipient = loadBooleanProperty(SECURITY_VALIDATE_RECIPIENT);
+		if (validateRecipient != null)
+			saml2Setting.setValidateRecipient(validateRecipient);
 	}
 
 	/**

--- a/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
+++ b/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
@@ -143,6 +143,8 @@ onelogin.saml2.security.want_xml_validation = true
 onelogin.saml2.security.validateTimes = true
 # Set to false to ignore audience problems in messages, good for testing
 onelogin.saml2.security.validateAudience = true
+# Set to false to ignore subject problems in messages, good for testing
+onelogin.saml2.security.validateRecipient = true
 
 # Algorithm that the toolkit will use on signing process. Options:
 #  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'

--- a/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
+++ b/samples/java-saml-tookit-jspsample/src/main/resources/onelogin.saml.properties
@@ -139,6 +139,11 @@ onelogin.saml2.security.onelogin.saml2.security.requested_authncontextcomparison
 # (In order to validate the xml, 'strict' and 'wantXMLValidation' must be true).
 onelogin.saml2.security.want_xml_validation = true
 
+# Set to false to ignore timing problems in messages, good for testing
+onelogin.saml2.security.validateTimes = true
+# Set to false to ignore audience problems in messages, good for testing
+onelogin.saml2.security.validateAudience = true
+
 # Algorithm that the toolkit will use on signing process. Options:
 #  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
 #  'http://www.w3.org/2000/09/xmldsig#dsa-sha1'


### PR DESCRIPTION
Added three new onelogin.saml.properties that can be used to test parsing assertions by suppressing timing, audience, and/or recipient validation.  Useful when my customers send me a sample assertion to test with, and it's too old to pass timing checks, or doesn't have the right audience.  Also useful when I try to reproduce problems on localhost, and the recipient url or audience in the assertion doesn't match my localhost settings.