### PR TITLE
Check the correct setting before signing Logout responses

### DIFF
--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -626,7 +626,7 @@ public class Auth {
 					parameters.put("RelayState", relayState);
 				}
 
-				if (settings.getLogoutRequestSigned()) {
+				if (settings.getLogoutResponseSigned()) {
 					String sigAlg = settings.getSignatureAlgorithm();
 					String signature = this.buildResponseSignature(samlLogoutResponse, relayState, sigAlg);
 


### PR DESCRIPTION
The `Auth#processSLO()` was checking the wrong setting to decide if the Logout Response message should be signed or not.