### PR TITLE
Add a getConditionsNotOnOrAfter method on SamlResponse

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -758,13 +758,29 @@ public class SamlResponse {
 	 *
 	 */
 	public List<Instant> getAssertionNotOnOrAfter() throws XPathExpressionException {
-		final NodeList notOnOrAfterNodes = queryAssertion("/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData");
+		return getNotOnOrAfter(queryAssertion("/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData"));
+	}
+
+	/**
+	 * @return a list of NotOnOrAfter values from Conditions nodes in this Response
+	 * @throws XPathExpressionException
+	 *
+	 */
+	public List<Instant> getConditionsNotOnOrAfter() throws XPathExpressionException {
+		return getNotOnOrAfter(queryAssertion("/saml:Conditions"));
+	}
+
+	/**
+	 * @param notOnOrAfterNodes The NodeList to get the NotOnOrAfter values.
+	 * @return a list of NotOnOrAfter values from a given NodeList.
+	 */
+	private List<Instant> getNotOnOrAfter(final NodeList notOnOrAfterNodes) {
 		final ArrayList<Instant> notOnOrAfters = new ArrayList<>();
 		for (int i = 0; i < notOnOrAfterNodes.getLength(); i++) {
 			final Node notOnOrAfterAttribute = notOnOrAfterNodes.item(i).getAttributes().getNamedItem("NotOnOrAfter");
 			if (notOnOrAfterAttribute != null) {
 				notOnOrAfters.add(new Instant(notOnOrAfterAttribute.getNodeValue()));
-		}}
+			}}
 		return notOnOrAfters;
 	}
 

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -844,6 +844,32 @@ public class AuthnResponseTest {
 		assertThat(notOnOrAfters, contains(new Instant("2120-06-17T14:53:44Z"), new Instant("2010-06-17T14:53:44Z")));
 	}
 
+	@Test
+	public void testGetConditionsDetails() throws IOException, Error, XPathExpressionException, ParserConfigurationException, SAXException, SettingsException, ValidationError {
+		final SamlResponse samlResponse = new SamlResponse(
+				new SettingsBuilder().fromFile("config/config.my.properties").build(),
+				newHttpRequest(Util.getFileAsString("data/responses/response1.xml.base64"))
+		);
+		final List<Instant> notOnOrAfters = samlResponse.getConditionsNotOnOrAfter();
+
+		assertEquals("pfxa46574df-b3b0-a06a-23c8-636413198772", samlResponse.getAssertionId());
+		assertThat(notOnOrAfters, contains(new Instant("2010-11-18T22:02:37Z")));
+
+	}
+
+	@Test
+	public void testGetConditionsDetails_encrypted() throws IOException, Error, XPathExpressionException, ParserConfigurationException, SAXException, SettingsException, ValidationError {
+		final SamlResponse samlResponse = new SamlResponse(
+				new SettingsBuilder().fromFile("config/config.my.properties").build(),
+				newHttpRequest(Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64"))
+		);
+		final List<Instant> notOnOrAfters = samlResponse.getConditionsNotOnOrAfter();
+
+		assertEquals("_519c2712648ee09a06d1f9a08e9e835715fea60267", samlResponse.getAssertionId());
+		assertThat(notOnOrAfters, contains(new Instant("2055-06-07T20:17:08Z")));
+
+	}
+
 	/**
 	 * Tests the getAttributes method of SamlResponse
 	 *


### PR DESCRIPTION
Because the Microsoft ADFS doesn't send the `SessionNotOnOrAfter` attribute on the `saml:AuthnStatement` element, I was planing to rely on the `NotOnOrAfter` attribute from the `saml:Conditions` element to know when the SSO session should be invalidated.

This pull request adds a `getConditionsNotOnOrAfter` method on `SamlResponse` to return the value of the `NotOnOrAfter` attribute from from the Conditions node.

Are you planing to release any version soon?