### PR TITLE
Fixed the logout error when sending Logoutresponse against ADFS

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -249,7 +249,11 @@ public class LogoutRequest {
 		} else {
 			nameId = settings.getIdpEntityId();
 			nameIdFormat = Constants.NAMEID_ENTITY;
-			spNameQualifier = settings.getSpEntityId();
+			
+			// If the format is unspecified, omit the SPEntityID. This will fix the error affecting ADFS on windows, 
+			// which complains about omitting the NameQualifier. @albertogeniola 02/11/2017
+			if (settings.getSpNameIDFormat().equals(Constants.NAMEID_UNSPECIFIED))
+				spNameQualifier = settings.getSpEntityId();
 		}
 
 		X509Certificate cert = null;


### PR DESCRIPTION
This fix solves the problem affecting Logout Request against the Windows AD FS. 
Without this fix, the LogoutRequest is sent with the SPNameQualifier set, while ADFS does not like it (ADFS behavior is correct according to the definition dictated by the Standard).