### PR TITLE
Inline slo signature

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -101,6 +101,7 @@ public final class Util {
 	public static final String UNIQUE_ID_PREFIX = "ONELOGIN_";
 	public static final String RESPONSE_SIGNATURE_XPATH = "/samlp:Response/ds:Signature";
 	public static final String ASSERTION_SIGNATURE_XPATH = "/samlp:Response/saml:Assertion/ds:Signature";
+	public static final String LOGOUT_RESPONSE_SIGNATURE_XPATH = "/samlp:LogoutResponse/ds:Signature";
 	/** Indicates if JAXP 1.5 support has been detected. */
 	private static boolean JAXP_15_SUPPORTED = isJaxp15Supported();
 


### PR DESCRIPTION
This week, I encountered an IdP that sent me a LogoutResponse containing a signature embedded within the SAMLResponse, instead of split out into separate Signature/SigAlg query parameters.  With much stealing from SamlResponse.java object, I added support for this type of signature.