### PR TITLE
Adjusted the core library, toolkit and the sample application to supp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ if (!errors.isEmpty()) {
         }
     }
 } else {
-    Map<String, List<String>> attributes = auth.getAttributes();
+    HashMap<String, List<String>> attributes = auth.getAttributes();
     String nameId = auth.getNameId();
     session.setAttribute("attributes", attributes);
     session.setAttribute("nameId", nameId);

--- a/core/src/main/java/com/onelogin/saml2/authn/NameID.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/NameID.java
@@ -1,0 +1,56 @@
+package com.onelogin.saml2.authn;
+
+/**
+ *	A utility class to keep a NameID sent by the IdP. 
+ *	Instances of this class are used to handle the SLO request to Shibboleth IdPv3, which requires that the NameID in the SLO
+ *	request carries all the four properties specified herunder - the NameIdFormat, NameQualifier, SPNameQualifier and the NameId. 
+ *	Instances of NameID are immutable and thread-safe.
+ * @author Rene Lauer (ray@phalanx.cz)
+ */
+public class NameID
+{
+	private final String format;
+	private final String nameQualifier;
+	private final String spNameQualifier;
+	private final String value;
+
+	public NameID(String format, String nameQualifier, String spNameQualifier, String value)
+	{
+		this.format = format;
+		this.nameQualifier = nameQualifier;
+		this.spNameQualifier = spNameQualifier;
+		this.value = value;
+	}
+
+	public String getFormat()
+	{
+		return format;
+	}
+
+	public String getNameQualifier()
+	{
+		return nameQualifier;
+	}
+
+	public String getSpNameQualifier()
+	{
+		return spNameQualifier;
+	}
+
+	public String getValue()
+	{
+		return value;
+	}
+	
+	public String toXML(String prefix)
+	{
+		String element = prefix == null ? "NameID" : prefix + ":NameID";
+		return "<" + element + 
+			(this.format == null ? "" : " Format=\"" + this.format + "\"") +
+			(this.nameQualifier == null ? "": " NameQualifier=\"" + this.nameQualifier + "\"") +
+			(this.spNameQualifier == null ? "": " SPNameQualifier=\"" + this.spNameQualifier + "\"") +
+			">" +
+			(this.value == null ? "" : this.value) +
+			"</" + element + ">";
+	}
+}

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -1,5 +1,6 @@
 package com.onelogin.saml2.util;
 
+import com.onelogin.saml2.authn.NameID;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1325,6 +1326,70 @@ public final class Util {
 				nameId.setAttribute("Format", format);
 			}
 			nameId.appendChild(doc.createTextNode(value));
+			doc.appendChild(nameId);
+
+			if (cert != null) {
+				// We generate a symmetric key
+				Key symmetricKey = generateSymmetricKey();
+
+				// cipher for encrypt the data
+				XMLCipher xmlCipher = XMLCipher.getInstance(Constants.AES128_CBC);
+				xmlCipher.init(XMLCipher.ENCRYPT_MODE, symmetricKey);
+
+				// cipher for encrypt the symmetric key
+				XMLCipher keyCipher = XMLCipher.getInstance(Constants.RSA_1_5);
+				keyCipher.init(XMLCipher.WRAP_MODE, cert.getPublicKey());
+
+				// encrypt the symmetric key
+				EncryptedKey encryptedKey = keyCipher.encryptKey(doc, symmetricKey);				
+
+				// Add keyinfo inside the encrypted data
+				EncryptedData encryptedData = xmlCipher.getEncryptedData();
+				KeyInfo keyInfo = new KeyInfo(doc);
+				keyInfo.add(encryptedKey);
+				encryptedData.setKeyInfo(keyInfo);
+
+				// Encrypt the actual data
+				xmlCipher.doFinal(doc, nameId, false);
+
+				// Building the result
+				res = "<saml:EncryptedID>" + convertDocumentToString(doc) + "</saml:EncryptedID>";
+			} else {
+				res = convertDocumentToString(doc);
+			}
+		} catch (Exception e) {
+			LOGGER.error("Error executing generateNameId: " + e.getMessage(), e);
+		}
+		return res;
+	}
+
+	/**
+	 * 	Generate a string representing the NameId carrying the three attributes and the value contained
+	 * 	in the supplied NameID instance.
+	 * 	This method code is copied from {@link #generateNameId(String value, String spnq, String format, X509Certificate cert) generateNameId}, with
+	 * 	replaced references to spnq and format with values from subject and added the NameQualifier to the resulting string.
+	 */
+	public static String generateNameId(NameID subject, X509Certificate cert) {
+		String res = null;
+		try {
+		  	DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		  	dbf.setNamespaceAware(true);
+			Document doc = dbf.newDocumentBuilder().newDocument();
+			Element nameId = doc.createElement("saml:NameID");
+			String spnq = subject.getSpNameQualifier();
+			String format = subject.getFormat();
+			String nq = subject.getNameQualifier();
+			if (spnq != null && !spnq.isEmpty()) {
+				nameId.setAttribute("SPNameQualifier", spnq);
+			}
+			if (format != null && !format.isEmpty()) {
+				nameId.setAttribute("Format", format);
+			}
+			if ((nq != null) && !nq.isEmpty())
+			{
+				nameId.setAttribute("NameQualifier", nq);
+			}
+			nameId.appendChild(doc.createTextNode(subject.getValue()));
 			doc.appendChild(nameId);
 
 			if (cert != null) {

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -152,14 +152,14 @@ public class LogoutRequestTest {
 	public void testConstructorWithSessionIndex() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		String sessionIndex = "_51be37965feb5579d803141076936dc2e9d1d98ebf";
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, null, sessionIndex); 
+		LogoutRequest logoutRequest = new LogoutRequest(settings, null, (String) null, sessionIndex); 
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		String expectedSessionIndex = "<samlp:SessionIndex>_51be37965feb5579d803141076936dc2e9d1d98ebf</samlp:SessionIndex>";
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
 		assertThat(logoutRequestStr, containsString(expectedSessionIndex));
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, null, (String) null, null);
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -231,7 +231,7 @@ public class LogoutRequestTest {
 		assertThat(nameIdDataStr, containsString("Value=ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		assertThat(nameIdDataStr, not(containsString("SPNameQualifier")));
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, null, (String)  null, null);
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -371,7 +371,7 @@ public class LogoutRequestTest {
 		String nameIdStr = LogoutRequest.getNameId(logoutRequestStr, null).toString();
 		assertEquals(expectedNameIdStr, nameIdStr);
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, null, (String) null, null);
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -486,7 +486,7 @@ public class LogoutRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		String sessionIndex = "_51be37965feb5579d803141076936dc2e9d1d98ebf";
 		expectedIndexes.add(sessionIndex);
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, null, sessionIndex); 
+		LogoutRequest logoutRequest = new LogoutRequest(settings, null, (String) null, sessionIndex); 
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		indexes = LogoutRequest.getSessionIndexes(logoutRequestStr);

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
@@ -7,6 +7,7 @@
 <%@page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
+<jsp:useBean class="java.util.HashMap" id="lgp" scope="session"/>
 <!DOCTYPE html>
 <html>
 <head>
@@ -36,7 +37,12 @@
 		if (!auth.isAuthenticated()) {
 			out.println("<div class=\"alert alert-danger\" role=\"alert\">Not authenticated</div>");
 		}
-
+		else
+		{
+			// added for the support of Sibboleth IdP3 logout.
+			lgp.put("subject", auth.getSubject());
+			lgp.put("session-index", auth.getSessionIndex());
+		}
 		List<String> errors = auth.getErrors();
 
 	    if (!errors.isEmpty()) {

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/dologout.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/dologout.jsp
@@ -1,6 +1,8 @@
 <%@page import="com.onelogin.saml2.Auth"%>
+<%@page import="com.onelogin.saml2.authn.NameID"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
+<jsp:useBean id="lgp" class="java.util.HashMap" scope="session"/>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
@@ -8,7 +10,15 @@
 <body>
 	<%
 		Auth auth = new Auth(request, response);
-		auth.logout();
+		if (lgp.isEmpty())
+			auth.logout();
+		else
+		{
+			// added for the support of Shibboleth IdP3 logout
+			NameID subject = (NameID) lgp.get("subject");
+			String sesionIndex = (String) lgp.get("session-index");
+			auth.logout(null, subject, sesionIndex, false);
+		}
 	%>
 </body>
 </html>

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -1275,12 +1275,12 @@ public class AuthTest {
 		settings.setLogoutRequestSigned(false);
 
 		Auth auth = new Auth(settings, request, response);
-		String target = auth.logout("", null, null, true);
+		String target = auth.logout("", (String) null, null, true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SingleLogoutService.php?SAMLRequest="));
 		assertThat(target, not(containsString("&RelayState=")));
 		
 		String relayState = "http://localhost:8080/expected.jsp";
-		target = auth.logout(relayState, null, null, true);
+		target = auth.logout(relayState, (String) null, null, true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SingleLogoutService.php?SAMLRequest="));
 		assertThat(target, containsString("&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp"));
 	}
@@ -1707,7 +1707,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
-		String targetSLOURL = auth.logout(null, null, null, true);
+		String targetSLOURL = auth.logout(null, (String) null, null, true);
 		String logoutRequestXML = auth.getLastRequestXML();
 		assertThat(targetSLOURL, containsString(Util.urlEncoder(Util.deflatedBase64encoded(logoutRequestXML))));
 	}


### PR DESCRIPTION
…ort logout from Shibboleth IdP3.

**This is a pull request in response to comments in issue #169** .

Changes made:
	- added NameID.java to com.onelogin.saml2.authn
	- adjusted LogoutRequest to use NameID instances and generate corresponding NameId XML element
	- adjusted Util.java to work with NameID
	- adjusted acs.jsp to extract NameID from login response
	- adjusted dologout.jsp to supply NameId and SessionIndex to Auth
	- added a logout() method to Auth.java that accepts a NameID as argument
	- adjusted LogoutRequestTest.java and AuthTest.java to work with the original methods (typecasts to resolve ambigous references)