### PR TITLE
Add custom requestId to AuthnRequest constructor

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -86,7 +86,26 @@ public class AuthnRequest {
 	 *            When true the AuthNReuqest will set a nameIdPolicy
 	 */
 	public AuthnRequest(Saml2Settings settings, boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy) {
-		this.id = Util.generateUniqueID();
+		this(settings, forceAuthn, isPassive, setNameIdPolicy, Util.generateUniqueID());
+	}
+
+	/**
+	 * Constructs the AuthnRequest object.
+	 *
+	 * @param settings
+	 *            OneLogin_Saml2_Settings
+	 * @param forceAuthn
+	 *            When true the AuthNReuqest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *            When true the AuthNReuqest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *            When true the AuthNReuqest will set a nameIdPolicy
+	 * @param requestId
+	 *            unique id for each request,
+	 *            in minimum "_" + UUID.randomUUID() as it should be a string that does not start with a number
+	 */
+	public AuthnRequest(Saml2Settings settings, boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy, String requestId) {
+		this.id = requestId;
 		issueInstant = Calendar.getInstance();
 		this.isPassive = isPassive;
 		this.settings = settings;

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -270,6 +271,25 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:RequestedAuthnContext Comparison=\"exact\">"));
 		assertThat(authnRequestStr, containsString("<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>"));
 		assertThat(authnRequestStr, containsString("<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:X509</saml:AuthnContextClassRef>"));
+	}
+
+	/**
+	 * Tests the AuthnRequest Constructor with custom requestId parameter
+	 *
+	 * @throws Exception
+	 *
+	 * @see com.onelogin.saml2.authn.AuthnRequest
+	 */
+	@Test
+	public void testAuthNConstructorWithCustomIdParamater() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+
+		String customRequestId = "_" + UUID.randomUUID();
+		AuthnRequest authnRequest = new AuthnRequest(settings, false, false, false, customRequestId);
+		String authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
+		String authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, containsString("ID=\"" + customRequestId));
 	}
 
 	/**


### PR DESCRIPTION
Currently hardcoded `ONELOGIN_` prefix in the id leaks the used library to all requests.
This change makes it possible to use a custom value in the SAMLRequest.

This change upholds the backwards compatibility with existing functionality.
