### PR TITLE
Fix: gather context path via Java

### DIFF
--- a/samples/java-saml-tookit-jspsample/src/main/webapp/dologin.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/dologin.jsp
@@ -11,8 +11,7 @@
 		if (request.getParameter("attrs") == null) {
 			auth.login();
 		} else {
-			String x = request.getPathInfo();
-			auth.login("/java-saml-tookit-jspsample/attrs.jsp");
+			auth.login(request.getContextPath() + "/attrs.jsp");
 		}
 	%>
 </body>


### PR DESCRIPTION
Remove the hardcoded context-path for the sample application.