### PR TITLE
Add a property for unique ID prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,11 @@ onelogin.saml2.contacts.technical.given_name = Technical Guy
 onelogin.saml2.contacts.technical.email_address = technical@example.com
 onelogin.saml2.contacts.support.given_name = Support Guy
 onelogin.saml2.contacts.support.email_address = support@example.com
+
+# Prefix used in generated Unique IDs.
+# Optional, defaults to ONELOGIN_ or full ID is like ONELOGIN_ebb0badd-4f60-4b38-b20a-a8e01f0592b1.
+# At minimun, the prefix can be non-numeric character such as "_".
+# onelogin.saml2.unique_id_prefix = _
 ```
 
 ##### Dynamic Settings

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -86,7 +86,7 @@ public class AuthnRequest {
 	 *            When true the AuthNReuqest will set a nameIdPolicy
 	 */
 	public AuthnRequest(Saml2Settings settings, boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy) {
-		this.id = Util.generateUniqueID();
+		this.id = Util.generateUniqueID(settings.getUniqueIDPrefix());
 		issueInstant = Calendar.getInstance();
 		this.isPassive = isPassive;
 		this.settings = settings;

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -132,7 +132,7 @@ public class LogoutRequest {
 		}
 	
 		if (samlLogoutRequest == null) {
-			id = Util.generateUniqueID();
+			id = Util.generateUniqueID(settings.getUniqueIDPrefix());
 			issueInstant = Calendar.getInstance();
 			this.nameId = nameId;
 			this.nameIdFormat = nameIdFormat;

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -343,7 +343,7 @@ public class LogoutResponse {
      *				InResponseTo attribute value to bet set at the Logout Response. 
      */
 	public void build(String inResponseTo) {
-		id = Util.generateUniqueID();
+		id = Util.generateUniqueID(settings.getUniqueIDPrefix());
 		issueInstant = Calendar.getInstance();
 		this.inResponseTo = inResponseTo;
 

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -139,7 +139,7 @@ public class Metadata {
 		Map<String, String> valueMap = new HashMap<String, String>();
 		Boolean wantsEncrypted = settings.getWantAssertionsEncrypted() || settings.getWantNameIdEncrypted(); 
 		
-		valueMap.put("id", Util.generateUniqueID());
+		valueMap.put("id", Util.generateUniqueID(settings.getUniqueIDPrefix()));
 		valueMap.put("validUntilTime", Util.formatDateTime(validUntilTime.getTimeInMillis()));
 		valueMap.put("cacheDuration", String.valueOf(cacheDuration));
 		valueMap.put("spEntityId", settings.getSpEntityId());

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -30,8 +30,6 @@ public class Saml2Settings {
      */
 	private static final Logger LOGGER = LoggerFactory.getLogger(Saml2Settings.class);
 
-	public static final String DEFAULT_UNIQUE_ID_PREFIX = "ONELOGIN_";
-
 	// Toolkit settings
 	private boolean strict = false;
 	private boolean debug = false;
@@ -75,7 +73,7 @@ public class Saml2Settings {
 	private String signatureAlgorithm = Constants.RSA_SHA1;
 	private String digestAlgorithm = Constants.SHA1;
 	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
-	private String uniqueIDPrefix = DEFAULT_UNIQUE_ID_PREFIX;
+	private String uniqueIDPrefix = null;
 
 	// Compress
 	private boolean compressRequest = true;

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -30,6 +30,8 @@ public class Saml2Settings {
      */
 	private static final Logger LOGGER = LoggerFactory.getLogger(Saml2Settings.class);
 
+	public static final String DEFAULT_UNIQUE_ID_PREFIX = "ONELOGIN_";
+
 	// Toolkit settings
 	private boolean strict = false;
 	private boolean debug = false;
@@ -73,6 +75,7 @@ public class Saml2Settings {
 	private String signatureAlgorithm = Constants.RSA_SHA1;
 	private String digestAlgorithm = Constants.SHA1;
 	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
+	private String uniqueIDPrefix = DEFAULT_UNIQUE_ID_PREFIX;
 
 	// Compress
 	private boolean compressRequest = true;
@@ -341,6 +344,13 @@ public class Saml2Settings {
 	}
 
 	/**
+	 * @return Unique ID prefix
+	 */
+	public String getUniqueIDPrefix() {
+		return this.uniqueIDPrefix;
+	}
+
+	/**
 	 * @return if the debug is active or not
 	 */
 	public boolean isDebugActive() {
@@ -445,6 +455,16 @@ public class Saml2Settings {
 	 */
 	protected final void setSpPrivateKey(PrivateKey spPrivateKey) {
 		this.spPrivateKey = spPrivateKey;
+	}
+
+	/**
+	 * Set the uniqueIDPrefix setting value
+	 *
+	 * @param uniqueIDPrefix
+	 *            the Unique ID prefix used when generating Unique ID
+	 */
+	protected final void setUniqueIDPrefix(String uniqueIDPrefix) {
+		this.uniqueIDPrefix = uniqueIDPrefix;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -103,6 +103,7 @@ public class SettingsBuilder {
 	public final static String ORGANIZATION_DISPLAYNAME = "onelogin.saml2.organization.displayname";
 	public final static String ORGANIZATION_URL = "onelogin.saml2.organization.url";
 	public final static String ORGANIZATION_LANG = "onelogin.saml2.organization.lang";
+	public final static String UNIQUE_ID_PREFIX_PROPERTY_KEY = "onelogin.saml2.unique_id_prefix";
 
 	/**
 	 * Load settings from the file
@@ -205,6 +206,8 @@ public class SettingsBuilder {
 		saml2Setting.setContacts(loadContacts());
 
 		saml2Setting.setOrganization(loadOrganization());
+
+		saml2Setting.setUniqueIDPrefix(loadUniqueIDPrefix());
 
 		return saml2Setting;
 	}
@@ -377,6 +380,18 @@ public class SettingsBuilder {
 		}
 
 		return contacts;
+	}
+
+	/**
+	 * Loads the unique ID prefix. Uses default if property not set.
+	 */
+	private String loadUniqueIDPrefix() {
+		String uniqueIDPrefix = loadStringProperty(UNIQUE_ID_PREFIX_PROPERTY_KEY);
+		if (StringUtils.isNotEmpty(uniqueIDPrefix)) {
+			return uniqueIDPrefix;
+		} else {
+			return Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX;
+		}
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -390,7 +390,7 @@ public class SettingsBuilder {
 		if (StringUtils.isNotEmpty(uniqueIDPrefix)) {
 			return uniqueIDPrefix;
 		} else {
-			return Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX;
+			return Util.UNIQUE_ID_PREFIX;
 		}
 	}
 

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -105,7 +105,6 @@ public final class Util {
 
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(DateTimeZone.UTC);
 	private static final DateTimeFormatter DATE_TIME_FORMAT_MILLS = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(DateTimeZone.UTC);
-	public static final String UNIQUE_ID_PREFIX = "ONELOGIN_";
 	public static final String RESPONSE_SIGNATURE_XPATH = "/samlp:Response/ds:Signature";
 	public static final String ASSERTION_SIGNATURE_XPATH = "/samlp:Response/saml:Assertion/ds:Signature";
 	/** Indicates if JAXP 1.5 support has been detected. */
@@ -1531,10 +1530,18 @@ public final class Util {
 	/**
 	 * Generates a unique string (used for example as ID of assertions)
 	 *
+	 * @param prefix
+	 *          Prefix for the Unique ID.
+	 *          Use property <code>onelogin.saml2.unique_id_prefix</code> to set this.
+	 *
 	 * @return A unique string
 	 */
-	public static String generateUniqueID() {
-		return UNIQUE_ID_PREFIX + UUID.randomUUID();
+	public static String generateUniqueID(String prefix) {
+		if (StringUtils.isNotEmpty(prefix)) {
+			return prefix + UUID.randomUUID();
+		} else {
+			throw new IllegalArgumentException("Prefix cannot be null or empty.");
+		}
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -105,6 +105,7 @@ public final class Util {
 
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(DateTimeZone.UTC);
 	private static final DateTimeFormatter DATE_TIME_FORMAT_MILLS = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(DateTimeZone.UTC);
+	public static final String UNIQUE_ID_PREFIX = "ONELOGIN_";
 	public static final String RESPONSE_SIGNATURE_XPATH = "/samlp:Response/ds:Signature";
 	public static final String ASSERTION_SIGNATURE_XPATH = "/samlp:Response/saml:Assertion/ds:Signature";
 	/** Indicates if JAXP 1.5 support has been detected. */
@@ -1537,11 +1538,19 @@ public final class Util {
 	 * @return A unique string
 	 */
 	public static String generateUniqueID(String prefix) {
-		if (StringUtils.isNotEmpty(prefix)) {
-			return prefix + UUID.randomUUID();
-		} else {
-			throw new IllegalArgumentException("Prefix cannot be null or empty.");
+		if (prefix == null || StringUtils.isEmpty(prefix)) {
+			prefix = Util.UNIQUE_ID_PREFIX;
 		}
+		return prefix + UUID.randomUUID();
+	}
+
+	/**
+	 * Generates a unique string (used for example as ID of assertions)
+	 *
+	 * @return A unique string
+	 */
+	public static String generateUniqueID() {
+		return generateUniqueID(null);
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
@@ -356,7 +356,42 @@ public class Saml2SettingsTest {
 		assertFalse(errors.isEmpty());
 		assertTrue(errors.contains("noEntityDescriptor_xml"));
 	}
-	
+
+	/**
+	 * Test that Unique ID prefix is read
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testGivenUniqueIDPrefixIsUsed() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.all.properties").build();
+
+		assertEquals("EXAMPLE", settings.getUniqueIDPrefix());
+	}
+
+	/**
+	 * Test that "_" value is ok for Unique ID prefix
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void testUniqueIDPrefixIsUsed() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min_uniqueid.properties").build();
+
+		assertEquals("_", settings.getUniqueIDPrefix());
+	}
+
+	/**
+	 * Tests that if property Unique ID prefix is unset, default value is used
+	 * @throws Exception
+	 */
+	@Test
+	public void testUniqueIDPrefixUsesDefaultWhenNotSet() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+
+		assertEquals("ONELOGIN_", settings.getUniqueIDPrefix());
+	}
+
 	/**
 	 * Tests the validateMetadata method of the Saml2Settings
 	 * Case Invalid: onlySPSSODescriptor_allowed_xml

--- a/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
@@ -166,6 +166,8 @@ public class SettingBuilderTest {
 
 		assertNull(setting.getOrganization());
 		assertTrue(setting.getContacts().isEmpty());
+
+		assertEquals("ONELOGIN_", setting.getUniqueIDPrefix());
 	}
 
 	/**
@@ -235,6 +237,8 @@ public class SettingBuilderTest {
 		assertEquals("support", c2.getContactType());
 		assertEquals("support@example.com", c2.getEmailAddress());
 		assertEquals("Support Guy", c2.getGivenName());
+
+		assertEquals("EXAMPLE", setting.getUniqueIDPrefix());
 	}
 
 	/**
@@ -523,6 +527,21 @@ public class SettingBuilderTest {
 	}
 
 	/**
+	 * Tests SettingsBuilder fromFile method
+	 * Case: min settings with minimal Unique ID config file
+	 *
+	 * @throws Exception
+	 *
+	 * @see com.onelogin.saml2.settings.SettingsBuilder#fromFile
+	 */
+	@Test
+	public void testLoadFromFileMinUniqueIDProp() throws Exception {
+		Saml2Settings setting = new SettingsBuilder().fromFile("config/config.min_uniqueid.properties").build();
+
+		assertEquals("_", setting.getUniqueIDPrefix());
+	}
+
+	/**
 	 * Tests SettingsBuilder fromProperties method
 	 *
 	 * @throws Error
@@ -586,6 +605,8 @@ public class SettingBuilderTest {
 
 		assertNull(setting2.getOrganization());
 		assertTrue(setting2.getContacts().isEmpty());
+
+		assertEquals("ONELOGIN_", setting2.getUniqueIDPrefix());
 	}
 	
 	/**
@@ -654,6 +675,8 @@ public class SettingBuilderTest {
 		samlData.put(CONTACT_TECHNICAL_EMAIL_ADDRESS, "technical@example.org");
 		samlData.put(CONTACT_SUPPORT_GIVEN_NAME, "Support Guy");
 		samlData.put(CONTACT_SUPPORT_EMAIL_ADDRESS, "support@example.org");
+
+		samlData.put(UNIQUE_ID_PREFIX_PROPERTY_KEY, "_");
 		
 		Saml2Settings setting = new SettingsBuilder().fromValues(samlData).build();
 		
@@ -717,6 +740,8 @@ public class SettingBuilderTest {
 		assertEquals("support", c2.getContactType());
 		assertEquals("support@example.org", c2.getEmailAddress());
 		assertEquals("Support Guy", c2.getGivenName());
+
+		assertEquals("_", setting.getUniqueIDPrefix());
 	}
 	
 	/**
@@ -840,6 +865,8 @@ public class SettingBuilderTest {
 		assertEquals("support", c2.getContactType());
 		assertEquals("support@example.org", c2.getEmailAddress());
 		assertEquals("Support Guy", c2.getGivenName());
+
+		assertEquals("ONELOGIN_", setting.getUniqueIDPrefix());
 	}
 	
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -1878,17 +1878,28 @@ public class UtilsTest {
 
 	/**
 	 * Tests the generateUniqueID method
+	 *
+	 * * @see com.onelogin.saml2.util.Util#generateUniqueID
+	 */
+	@Test
+	public void testGenerateUniqueID() {
+		String s1 = Util.generateUniqueID();
+		assertThat(s1, startsWith(Util.UNIQUE_ID_PREFIX));
+	}
+
+	/**
+	 * Tests the generateUniqueID method
 	 * 
 	 * @see com.onelogin.saml2.util.Util#generateUniqueID
 	 */
 	@Test
-	public void testGenerateUniqueID() {
-		String s1 = Util.generateUniqueID(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX);
+	public void testGenerateUniqueID_withCustomPrefix() {
+		String s1 = Util.generateUniqueID(Util.UNIQUE_ID_PREFIX);
 
-		assertThat(s1, startsWith(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX));
+		assertThat(s1, startsWith(Util.UNIQUE_ID_PREFIX));
 		assertTrue(s1.length() > 40);
 		
-		String s2 = Util.generateUniqueID(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX);
+		String s2 = Util.generateUniqueID(Util.UNIQUE_ID_PREFIX);
 		String s3 = Util.generateUniqueID("_");
 		assertThat(s3, startsWith("_"));
 
@@ -1898,19 +1909,21 @@ public class UtilsTest {
 	}
 
 	/**
-	 * Tests that generateUniqueID method throws when given null
+	 * Tests that generateUniqueID method uses default prefix when given null
 	 */
-	@Test(expected=IllegalArgumentException.class)
-	public void testGenerateUniqueID_throwsOnNullPrefix() {
-		Util.generateUniqueID(null);
+	@Test
+	public void testGenerateUniqueID_usesDefaultOnNull() {
+		String s1 = Util.generateUniqueID(null);
+		assertThat(s1, startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**
-	 * Tests that generateUniqueID method throws when given empty String
+	 * Tests that generateUniqueID method uses default prefix when given empty String
 	 */
-	@Test(expected=IllegalArgumentException.class)
-	public void testGenerateUniqueID_throwsOnEmptyPrefix() {
-		Util.generateUniqueID("");
+	@Test
+	public void testGenerateUniqueID_usesDefaultOnEmpty() {
+		String s1 = Util.generateUniqueID("");
+		assertThat(s1, startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/util/UtilsTest.java
@@ -52,6 +52,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.SchemaFactory;
 import com.onelogin.saml2.util.Util;
@@ -1882,16 +1883,34 @@ public class UtilsTest {
 	 */
 	@Test
 	public void testGenerateUniqueID() {
-		String s1 = Util.generateUniqueID();
+		String s1 = Util.generateUniqueID(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX);
 
-		assertThat(s1, startsWith(Util.UNIQUE_ID_PREFIX));
+		assertThat(s1, startsWith(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX));
 		assertTrue(s1.length() > 40);
 		
-		String s2 = Util.generateUniqueID();
-		String s3 = Util.generateUniqueID();
+		String s2 = Util.generateUniqueID(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX);
+		String s3 = Util.generateUniqueID("_");
+		assertThat(s3, startsWith("_"));
+
 		assertNotEquals(s1, s2);
 		assertNotEquals(s1, s3);
 		assertNotEquals(s2, s3);
+	}
+
+	/**
+	 * Tests that generateUniqueID method throws when given null
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testGenerateUniqueID_throwsOnNullPrefix() {
+		Util.generateUniqueID(null);
+	}
+
+	/**
+	 * Tests that generateUniqueID method throws when given empty String
+	 */
+	@Test(expected=IllegalArgumentException.class)
+	public void testGenerateUniqueID_throwsOnEmptyPrefix() {
+		Util.generateUniqueID("");
 	}
 
 	/**

--- a/core/src/test/resources/config/config.all.properties
+++ b/core/src/test/resources/config/config.all.properties
@@ -145,3 +145,8 @@ onelogin.saml2.contacts.technical.given_name = Technical Guy
 onelogin.saml2.contacts.technical.email_address = technical@example.com
 onelogin.saml2.contacts.support.given_name = Support Guy
 onelogin.saml2.contacts.support.email_address = support@example.com
+
+# Prefix used in generated Unique IDs.
+# Optional, defaults to ONELOGIN_ or full ID is like ONELOGIN_ebb0badd-4f60-4b38-b20a-a8e01f0592b1.
+# At minimun, the prefix can be non-numeric character such as "_".
+onelogin.saml2.unique_id_prefix = EXAMPLE

--- a/core/src/test/resources/config/config.min_uniqueid.properties
+++ b/core/src/test/resources/config/config.min_uniqueid.properties
@@ -1,0 +1,31 @@
+#  Service Provider Data that we are deploying
+#  Identifier of the SP entity  (must be a URI)
+onelogin.saml2.sp.entityid = http://localhost:8080/java-saml-jspsample/metadata.jsp
+# Specifies info about where and how the <AuthnResponse> message MUST be
+#  returned to the requester, in this case our SP.
+# URL Location where the <Response> from the IdP will be returned
+onelogin.saml2.sp.assertion_consumer_service.url = http://localhost:8080/java-saml-jspsample/acs.jsp
+
+# Specifies info about Logout service
+# URL Location where the <LogoutResponse> from the IdP will be returned or where to send the <LogoutRequest>
+onelogin.saml2.sp.single_logout_service.url = http://localhost:8080/java-saml-jspsample/sls.jsp
+
+# Identity Provider Data that we want connect with our SP
+# Identifier of the IdP entity  (must be a URI)
+onelogin.saml2.idp.entityid = http://idp.example.com/
+
+# SSO endpoint info of the IdP. (Authentication Request protocol)
+# URL Target of the IdP where the SP will send the Authentication Request Message
+onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesaml/saml2/idp/SSOService.php
+
+# SLO endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Request
+onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
+
+# Public x509 certificate of the IdP
+onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----
+
+# Prefix used in generated Unique IDs.
+# Optional, defaults to ONELOGIN_ or full ID is like ONELOGIN_ebb0badd-4f60-4b38-b20a-a8e01f0592b1.
+# At minimun, the prefix can be non-numeric character such as "_".
+onelogin.saml2.unique_id_prefix = _

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -1065,7 +1065,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		auth.login();
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SSOService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
-		assertThat(auth.getLastRequestId(), startsWith(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX));
+		assertThat(auth.getLastRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**
@@ -1251,7 +1251,7 @@ public class AuthTest {
 		auth.logout();
 
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
-		assertThat(auth.getLastRequestId(), startsWith(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX));
+		assertThat(auth.getLastRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
 	}
 
 	/**

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -1065,7 +1065,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		auth.login();
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SSOService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
-		assertThat(auth.getLastRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
+		assertThat(auth.getLastRequestId(), startsWith(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX));
 	}
 
 	/**
@@ -1251,7 +1251,7 @@ public class AuthTest {
 		auth.logout();
 
 		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SingleLogoutService.php\\?SAMLRequest=(.)*&RelayState=http%3A%2F%2Flocalhost%3A8080%2Finitial.jsp"));
-		assertThat(auth.getLastRequestId(), startsWith(Util.UNIQUE_ID_PREFIX));
+		assertThat(auth.getLastRequestId(), startsWith(Saml2Settings.DEFAULT_UNIQUE_ID_PREFIX));
 	}
 
 	/**


### PR DESCRIPTION
Made it possible to change the prefix of unique ID through properties.
If property is not set the default value of "ONELOGIN_" is used.

This PR overrides #185