### PR TITLE
Changed code to use specific XPathFactoryImpl

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -57,6 +57,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathFactoryConfigurationException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -121,18 +122,18 @@ public final class Util {
 	}
 
 	/**
-	 * Method which uses the recommended way ( https://docs.oracle.com/javase/tutorial/jaxp/properties/error.html ) 
+	 * Method which uses the recommended way ( https://docs.oracle.com/javase/tutorial/jaxp/properties/error.html )
 	 * of checking if JAXP >= 1.5 options are supported. Needed if the project which uses this library also has
-	 * Xerces in it's classpath. 
-	 * 
+	 * Xerces in it's classpath.
+	 *
 	 * If for whatever reason this method cannot determine if JAXP 1.5 properties are supported it will indicate the
 	 * options are supported. This way we don't accidentally disable configuration options.
 	 *
 	 * @return
 	 */
 	public static boolean isJaxp15Supported() {
-		boolean supported = true;		
-		
+		boolean supported = true;
+
 		try {
 			SAXParserFactory spf = SAXParserFactory.newInstance();
 			SAXParser parser = spf.newSAXParser();
@@ -146,10 +147,10 @@ public final class Util {
 		} catch (Exception e) {
 			LOGGER.info("An exception occurred while trying to determine if JAXP 1.5 options are supported.", e);
 		}
-		
+
 		return supported;
 	}
-	
+
 	/**
 	 * This function load an XML string in a save way. Prevent XEE/XXE Attacks
 	 *
@@ -173,6 +174,37 @@ public final class Util {
 		return null;
 	}
 
+	private static XPathFactory getXPathFactory() {
+		try {
+			/*
+			 * Since different environments may return a different XPathFactoryImpl, we should try to initialize the factory
+			 * using specific implementation that way the XML is parsed in an expected way.
+			 *
+			 * We should use the standard XPathFactoryImpl that comes standard with Java.
+			 *
+			 * NOTE: We could implement a check to see if the "javax.xml.xpath.XPathFactory" System property exists and is set
+			 *       to a value, if people have issues with using the specified implementor. This would allow users to always
+			 *       override the implementation if they so need to.
+			 */
+			return XPathFactory.newInstance(XPathFactory.DEFAULT_OBJECT_MODEL_URI, "com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl", java.lang.ClassLoader.getSystemClassLoader());
+		} catch (XPathFactoryConfigurationException e) {
+			LOGGER.debug("Error generating XPathFactory instance: " + e.getMessage(), e);
+		}
+
+		/*
+		 * If the expected XPathFactory did not exist, we fallback to loading the one defined as the default.
+		 *
+		 * If this is still throwing an error, the developer can set the "javax.xml.xpath.XPathFactory" system property
+		 * to specify the default XPathFactoryImpl implementation to use. For example:
+		 *
+		 * -Djavax.xml.xpath.XPathFactory:http://java.sun.com/jaxp/xpath/dom=net.sf.saxon.xpath.XPathFactoryImpl
+		 * -Djavax.xml.xpath.XPathFactory:http://java.sun.com/jaxp/xpath/dom=com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl
+		 *
+		 */
+		return XPathFactory.newInstance();
+	}
+
+
 	/**
 	 * Extracts a node from the DOMDocument
 	 *
@@ -189,7 +221,7 @@ public final class Util {
 	 */
 	public static NodeList query(Document dom, String query, Node context) throws XPathExpressionException {
 		NodeList nodeList;
-		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPath xpath = getXPathFactory().newXPath();
 		xpath.setNamespaceContext(new NamespaceContext() {
 
 			@Override
@@ -264,7 +296,7 @@ public final class Util {
 
 			Schema schema = SchemaFactory.loadFromUrl(schemaUrl);
 			Validator validator = schema.newValidator();
-			
+
 			if (JAXP_15_SUPPORTED) {
 				// Prevent XXE attacks
 				validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -296,9 +328,9 @@ public final class Util {
 	 *
 	 * @return the Document object
 	 *
-	 * @throws ParserConfigurationException 
-	 * @throws SAXException 
-	 * @throws IOException 
+	 * @throws ParserConfigurationException
+	 * @throws SAXException
+	 * @throws IOException
 	 */
 	public static Document convertStringToDocument(String xmlStr) throws ParserConfigurationException, SAXException, IOException {
 		return parseXML(new InputSource(new StringReader(xmlStr)));
@@ -312,19 +344,19 @@ public final class Util {
 	 *
 	 * @return the Document object
 	 *
-	 * @throws ParserConfigurationException 
-	 * @throws SAXException 
-	 * @throws IOException 
+	 * @throws ParserConfigurationException
+	 * @throws SAXException
+	 * @throws IOException
 	 */
 	public static Document parseXML(InputSource inputSource) throws ParserConfigurationException, SAXException, IOException {
 		DocumentBuilderFactory docfactory = DocumentBuilderFactory.newInstance();
 		docfactory.setNamespaceAware(true);
-		
-		// do not expand entity reference nodes 
+
+		// do not expand entity reference nodes
 		docfactory.setExpandEntityReferences(false);
-		
+
 		docfactory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaLanguage", XMLConstants.W3C_XML_SCHEMA_NS_URI);
-		
+
 		// Add various options explicitly to prevent XXE attacks.
 		// (adding try/catch around every setAttribute just in case a specific parser does not support it.
 		try {
@@ -358,7 +390,7 @@ public final class Util {
 
 		// Loop through the doc and tag every element with an ID attribute
 		// as an XML ID node.
-		XPath xpath = XPathFactory.newInstance().newXPath();
+		XPath xpath = getXPathFactory().newXPath();
 		XPathExpression expr;
 		try {
 			expr = xpath.compile("//*[@ID]");
@@ -393,12 +425,12 @@ public final class Util {
 		} else {
 			XMLUtils.outputDOM(doc, baos);
 		}
-		
+
 		return Util.toStringUtf8(baos.toByteArray());
 	}
-	
+
 	/**
-	 * Converts an XML in Document format in a String without applying the c14n transformation 
+	 * Converts an XML in Document format in a String without applying the c14n transformation
 	 *
 	 * @param doc
 	 * 				The Document object
@@ -422,12 +454,12 @@ public final class Util {
 	public static String formatCert(String cert, Boolean heads) {
 		String x509cert = StringUtils.EMPTY;
 
-		if (cert != null) {		
+		if (cert != null) {
 			x509cert = cert.replace("\\x0D", "").replace("\r", "").replace("\n", "").replace(" ", "");
 
 			if (!StringUtils.isEmpty(x509cert)) {
 				x509cert = x509cert.replace("-----BEGINCERTIFICATE-----", "").replace("-----ENDCERTIFICATE-----", "");
-			
+
 				if (heads) {
 					x509cert = "-----BEGIN CERTIFICATE-----\n" + chunkString(x509cert, 64) + "-----END CERTIFICATE-----";
 				}
@@ -451,27 +483,27 @@ public final class Util {
 
 		if (key != null) {
 			xKey = key.replace("\\x0D", "").replace("\r", "").replace("\n", "").replace(" ", "");
-	
+
 			if (!StringUtils.isEmpty(xKey)) {
 				if (xKey.startsWith("-----BEGINPRIVATEKEY-----")) {
 					xKey = xKey.replace("-----BEGINPRIVATEKEY-----", "").replace("-----ENDPRIVATEKEY-----", "");
-	
+
 					if (heads) {
 						xKey = "-----BEGIN PRIVATE KEY-----\n" + chunkString(xKey, 64) + "-----END PRIVATE KEY-----";
 					}
 				} else {
-	
+
 					xKey = xKey.replace("-----BEGINRSAPRIVATEKEY-----", "").replace("-----ENDRSAPRIVATEKEY-----", "");
-	
+
 					if (heads) {
 						xKey = "-----BEGIN RSA PRIVATE KEY-----\n" + chunkString(xKey, 64) + "-----END RSA PRIVATE KEY-----";
 					}
 				}
 			}
 		}
-			
+
 		return xKey;
-	}	
+	}
 
 	/**
 	 * chunk a string
@@ -495,7 +527,7 @@ public final class Util {
 		return newStr;
 	}
 
-	
+
 	/**
 	 * Load X.509 certificate
 	 *
@@ -504,13 +536,13 @@ public final class Util {
 	 *
 	 * @return Loaded Certificate. X509Certificate object
 	 *
-	 * @throws CertificateException 
+	 * @throws CertificateException
 	 *
 	 */
 	public static X509Certificate loadCert(String certString) throws CertificateException {
 		certString = formatCert(certString, true);
 		X509Certificate cert;
-		
+
 		try {
 			cert = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(
 				new ByteArrayInputStream(certString.getBytes(StandardCharsets.UTF_8)));
@@ -522,19 +554,19 @@ public final class Util {
 
 	/**
 	 * Load private key
-	 * 
+	 *
 	 * @param keyString
 	 * 				 private key in string format
 	 *
 	 * @return Loaded private key. PrivateKey object
 	 *
-	 * @throws GeneralSecurityException 
+	 * @throws GeneralSecurityException
 	 */
 	public static PrivateKey loadPrivateKey(String keyString) throws GeneralSecurityException {
 		String extractedKey = formatPrivateKey(keyString, false);
 		extractedKey = chunkString(extractedKey, 64);
 		KeyFactory kf = KeyFactory.getInstance("RSA");
-		
+
 		PrivateKey privKey;
 		try {
 			byte[] encoded = Base64.decodeBase64(extractedKey);
@@ -550,7 +582,7 @@ public final class Util {
 
 	/**
 	 * Calculates the fingerprint of a x509cert
-	 * 
+	 *
 	 * @param x509cert
 	 * 				 x509 certificate
 	 * @param alg
@@ -582,7 +614,7 @@ public final class Util {
 
 	/**
 	 * Calculates the SHA-1 fingerprint of a x509cert
-	 * 
+	 *
 	 * @param x509cert
 	 * 				 x509 certificate
 	 *
@@ -615,7 +647,7 @@ public final class Util {
 			LOGGER.debug("Error converting certificate on PEM format: "+ e.getMessage(), e);
 		}
 		return pemCert;
-	}	
+	}
 
 	/**
 	 * Loads a resource located at a relative path
@@ -665,7 +697,7 @@ public final class Util {
 		}
 		// Base64 decoder
 		byte[] decoded = Base64.decodeBase64(input);
-		
+
 		// Inflater
 		try {
 			Inflater decompresser = new Inflater(true);
@@ -675,7 +707,7 @@ public final class Util {
 		    long limit = 0;
 		    while(!decompresser.finished() && limit < 150) {
 		    	int resultLength = decompresser.inflate(result);
-		    	limit += 1; 
+		    	limit += 1;
 		    	inflated += new String(result, 0, resultLength, "UTF-8");
 		    }
 		    decompresser.end();
@@ -692,7 +724,7 @@ public final class Util {
 	 *				String input
 	 *
 	 * @return the deflated and base64 encoded string
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	public static String deflatedBase64encoded(String input) throws IOException {
 		// Deflater
@@ -725,7 +757,7 @@ public final class Util {
 	 *
 	 * @return the base64 encoded string
 	 */
-	public static String base64encoder(String input) {		
+	public static String base64encoder(String input) {
 		return base64encoder(toBytesUtf8(input));
 	}
 
@@ -737,7 +769,7 @@ public final class Util {
 	 *
 	 * @return the base64 decoded bytes
 	 */
-	public static byte[] base64decoder(byte [] input) {		
+	public static byte[] base64decoder(byte [] input) {
 		return Base64.decodeBase64(input);
 	}
 
@@ -749,7 +781,7 @@ public final class Util {
 	 *
 	 * @return the base64 decoded bytes
 	 */
-	public static byte[] base64decoder(String input) {		
+	public static byte[] base64decoder(String input) {
 		return base64decoder(toBytesUtf8(input));
 	}
 
@@ -806,7 +838,7 @@ public final class Util {
 	 * 				 Signature algorithm method
 	 *
 	 * @return the signature
-	 * 
+	 *
 	 * @throws NoSuchAlgorithmException
 	 * @throws InvalidKeyException
 	 * @throws SignatureException
@@ -845,7 +877,7 @@ public final class Util {
 			convertedSignatureAlg = "SHA384withRSA";
 		} else if (sign.equals(Constants.RSA_SHA512)) {
 			convertedSignatureAlg = "SHA512withRSA";
-		} else {			
+		} else {
 			convertedSignatureAlg = "SHA1withRSA";
 		}
 
@@ -869,11 +901,11 @@ public final class Util {
 			final NodeList signatures = query(doc, xpath);
 			return signatures.getLength() == 1 && validateSignNode(signatures.item(0), cert, fingerprint, alg);
 		} catch (XPathExpressionException e) {
-			LOGGER.warn("Failed to find signature nodes", e);		
+			LOGGER.warn("Failed to find signature nodes", e);
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Validate the signature pointed to by the xpath
 	 *
@@ -928,7 +960,7 @@ public final class Util {
 
 			if (signNodesToValidate.getLength() == 0) {
 				signNodesToValidate = query(doc, "/md:EntityDescriptor/ds:Signature");
-				
+
 				if (signNodesToValidate.getLength() == 0) {
 					signNodesToValidate = query(doc, "/md:EntityDescriptor/md:SPSSODescriptor/ds:Signature|/md:EntityDescriptor/IDPSSODescriptor/ds:Signature");
 				}
@@ -1081,7 +1113,7 @@ public final class Util {
 	 *
  	 * @return the clone of the Document object
  	 *
-	 * @throws ParserConfigurationException 
+	 * @throws ParserConfigurationException
 	 */
 	public static Document copyDocument(Document source) throws ParserConfigurationException
 	{
@@ -1094,7 +1126,7 @@ public final class Util {
         Document copiedDocument = db.newDocument();
         Node copiedRoot = copiedDocument.importNode(originalRoot, true);
         copiedDocument.appendChild(copiedRoot);
-        
+
         return copiedDocument;
 	}
 
@@ -1173,7 +1205,7 @@ public final class Util {
 		// Including the signature into the document before sign, because
 		// this is an envelop signature
 		Element root = document.getDocumentElement();
-		document.setXmlStandalone(false);		
+		document.setXmlStandalone(false);
 
 		// If Issuer, locate Signature after Issuer, Otherwise as first child.
 		NodeList issuerNodes = Util.query(document, "//saml:Issuer", null);
@@ -1288,13 +1320,13 @@ public final class Util {
 	 * 				 The public certificate
 	 * @param signAlg
 	 * 				 Signature Algorithm
-	 * 
+	 *
 	 * @return the signed document in string format
 	 *
 	 * @throws NoSuchAlgorithmException
-	 * @throws NoSuchProviderException 
-	 * @throws InvalidKeyException 
-	 * @throws SignatureException 
+	 * @throws NoSuchProviderException
+	 * @throws InvalidKeyException
+	 * @throws SignatureException
 	 */
 	public static Boolean validateBinarySignature(String signedQuery, byte[] signature, X509Certificate cert, String signAlg) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeyException, SignatureException {
 		Boolean valid = false;
@@ -1304,7 +1336,7 @@ public final class Util {
 			Signature sig = Signature.getInstance(convertedSigAlg); //, provider);
 			sig.initVerify(cert.getPublicKey());
 			sig.update(signedQuery.getBytes());
-			
+
 			valid = sig.verify(signature);
 		} catch (Exception e) {
 			LOGGER.warn("Error executing validateSign: " + e.getMessage(), e);
@@ -1323,13 +1355,13 @@ public final class Util {
 	 * 				 The List of certificates
 	 * @param signAlg
 	 * 				 Signature Algorithm
-	 * 
+	 *
 	 * @return the signed document in string format
 	 *
 	 * @throws NoSuchAlgorithmException
-	 * @throws NoSuchProviderException 
-	 * @throws InvalidKeyException 
-	 * @throws SignatureException 
+	 * @throws NoSuchProviderException
+	 * @throws InvalidKeyException
+	 * @throws SignatureException
 	 */
 	public static Boolean validateBinarySignature(String signedQuery, byte[] signature, List<X509Certificate> certList, String signAlg) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeyException, SignatureException {
 		Boolean valid = false;
@@ -1338,7 +1370,7 @@ public final class Util {
 		Signature sig = Signature.getInstance(convertedSigAlg); //, provider);
 
 		for (X509Certificate cert : certList) {
-			try {	
+			try {
 				sig.initVerify(cert.getPublicKey());
 				sig.update(signedQuery.getBytes());
 				valid = sig.verify(signature);
@@ -1447,7 +1479,7 @@ public final class Util {
 				keyCipher.init(XMLCipher.WRAP_MODE, cert.getPublicKey());
 
 				// encrypt the symmetric key
-				EncryptedKey encryptedKey = keyCipher.encryptKey(doc, symmetricKey);				
+				EncryptedKey encryptedKey = keyCipher.encryptKey(doc, symmetricKey);
 
 				// Add keyinfo inside the encrypted data
 				EncryptedData encryptedData = xmlCipher.getEncryptedData();
@@ -1483,10 +1515,10 @@ public final class Util {
 	 *
 	 * @return Xml contained in the document.
 	 */
-	public static String generateNameId(String value, String spnq, String format, X509Certificate cert) {		
+	public static String generateNameId(String value, String spnq, String format, X509Certificate cert) {
 		return generateNameId(value, spnq, format, null, cert);
 	}
-	
+
 	/**
 	 * Generates a nameID.
 	 *
@@ -1514,10 +1546,10 @@ public final class Util {
 	public static String generateNameId(String value) {
 		return generateNameId(value, null, null, null);
 	}
-	
+
 	/**
 	 * Method to generate a symmetric key for encryption
-	 * 
+	 *
 	 * @return the symmetric key
 	 *
 	 * @throws Exception
@@ -1573,7 +1605,7 @@ public final class Util {
 	 *
 	 * @param durationString
 	 * 				 The duration, as a string.
-	 * @param timestamp 
+	 * @param timestamp
 	 *               The unix timestamp we should apply the duration to.
 	 *
 	 * @return the new timestamp, after the duration is applied In Seconds.
@@ -1582,7 +1614,7 @@ public final class Util {
 	 */
 	public static long parseDuration(String durationString, long timestamp) throws IllegalArgumentException {
 		boolean haveMinus = false;
-	
+
 		if (durationString.startsWith("-")) {
 			durationString = durationString.substring(1);
 			haveMinus = true;
@@ -1601,7 +1633,7 @@ public final class Util {
 		}
 		return result.getMillis() / 1000;
 	}
-	  
+
 	/**
 	 * @return the unix timestamp that matches the current time.
 	 */
@@ -1626,7 +1658,7 @@ public final class Util {
 			if (cacheDuration != null && !StringUtils.isEmpty(cacheDuration)) {
 				expireTime = parseDuration(cacheDuration);
 			}
-	
+
 			if (validUntil != null && !StringUtils.isEmpty(validUntil)) {
 				DateTime dt = Util.parseDateTime(validUntil);
 				long validUntilTimeInt = dt.getMillis() / 1000;
@@ -1655,8 +1687,8 @@ public final class Util {
 		try {
 			if (cacheDuration != null && !StringUtils.isEmpty(cacheDuration)) {
 				expireTime = parseDuration(cacheDuration);
-			}	
-			
+			}
+
 			if (expireTime == 0 || expireTime > validUntil) {
 				expireTime = validUntil;
 			}
@@ -1665,7 +1697,7 @@ public final class Util {
 		}
 		return expireTime;
 	}
-	
+
 	/**
 	 * Create string form time In Millis with format yyyy-MM-ddTHH:mm:ssZ
 	 *
@@ -1705,7 +1737,7 @@ public final class Util {
 	 * @return datetime
 	 */
 	public static DateTime parseDateTime(String dateTime) {
-		
+
 		DateTime parsedData = null;
 		try {
 			parsedData = DATE_TIME_FORMAT.parseDateTime(dateTime);
@@ -1731,5 +1763,5 @@ public final class Util {
 		}
 	}
 
-	
+
 }


### PR DESCRIPTION
This changes the XPathFactory call to use a specific XPathFactoryImpl to avoid issues where an environment may be using a default implementation that's incompatible with the code (such as using an outdated Saxon parser). This change attempts to use the default Java implementation, but if that is unavailable will fallback to try to load the default.

This will also help to ensure the XML is always parsed in a consistent manor, since everyone should be using the same XPathFactoryImpl.

This should resolve Issue #191.