### PR TITLE
IDP SAML Response verification parametrized

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -280,31 +280,33 @@ public class SamlResponse {
 				}
 			}
 
-			if (signedElements.isEmpty() || (!hasSignedAssertion && !hasSignedResponse)) {
-				throw new ValidationError("No Signature found. SAML Response rejected", ValidationError.NO_SIGNATURE_FOUND);
-			} else {
-				X509Certificate cert = settings.getIdpx509cert();
-				List<X509Certificate> certList = new ArrayList<>();
-				List<X509Certificate> multipleCertList = settings.getIdpx509certMulti();
+			if(settings.getVerifyResponseSignature()) {
+				if (signedElements.isEmpty() || (!hasSignedAssertion && !hasSignedResponse)) {
+					throw new ValidationError("No Signature found. SAML Response rejected", ValidationError.NO_SIGNATURE_FOUND);
+				} else {
+					X509Certificate cert = settings.getIdpx509cert();
+					List<X509Certificate> certList = new ArrayList<>();
+					List<X509Certificate> multipleCertList = settings.getIdpx509certMulti();
 
-				if (multipleCertList != null && !multipleCertList.isEmpty()) {
-					certList.addAll(multipleCertList);
-				}
+					if (multipleCertList != null && !multipleCertList.isEmpty()) {
+						certList.addAll(multipleCertList);
+					}
 
-				if (cert != null && !certList.contains(cert)) {
-					certList.add(0, cert);
-				}
+					if (cert != null && !certList.contains(cert)) {
+						certList.add(0, cert);
+					}
 
-				String fingerprint = settings.getIdpCertFingerprint();
-				String alg = settings.getIdpCertFingerprintAlgorithm();
+					String fingerprint = settings.getIdpCertFingerprint();
+					String alg = settings.getIdpCertFingerprintAlgorithm();
 
-				if (hasSignedResponse && !Util.validateSign(samlResponseDocument, certList, fingerprint, alg, Util.RESPONSE_SIGNATURE_XPATH)) {
-					throw new ValidationError("Signature validation failed. SAML Response rejected", ValidationError.INVALID_SIGNATURE);
-				}
+					if (hasSignedResponse && !Util.validateSign(samlResponseDocument, certList, fingerprint, alg, Util.RESPONSE_SIGNATURE_XPATH)) {
+						throw new ValidationError("Signature validation failed. SAML Response rejected", ValidationError.INVALID_SIGNATURE);
+					}
 
-				final Document documentToCheckAssertion = encrypted ? decryptedDocument : samlResponseDocument;
-				if (hasSignedAssertion && !Util.validateSign(documentToCheckAssertion, certList, fingerprint, alg, Util.ASSERTION_SIGNATURE_XPATH)) {
-					throw new ValidationError("Signature validation failed. SAML Response rejected", ValidationError.INVALID_SIGNATURE);
+					final Document documentToCheckAssertion = encrypted ? decryptedDocument : samlResponseDocument;
+					if (hasSignedAssertion && !Util.validateSign(documentToCheckAssertion, certList, fingerprint, alg, Util.ASSERTION_SIGNATURE_XPATH)) {
+						throw new ValidationError("Signature validation failed. SAML Response rejected", ValidationError.INVALID_SIGNATURE);
+					}
 				}
 			}
 

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -74,6 +74,7 @@ public class Saml2Settings {
 	private String digestAlgorithm = Constants.SHA1;
 	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
 	private String uniqueIDPrefix = null;
+	private boolean verifyResponseSignature = true;
 
 	// Compress
 	private boolean compressRequest = true;
@@ -791,6 +792,14 @@ public class Saml2Settings {
 	 */
 	protected final void setOrganization(Organization organization) {
 		this.organization = organization;
+	}
+
+	public boolean getVerifyResponseSignature() {
+		return verifyResponseSignature;
+	}
+
+	public void setVerifyResponseSignature(boolean val) {
+		this.verifyResponseSignature = val;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -88,6 +88,7 @@ public class SettingsBuilder {
 	public final static String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
 	public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
 	public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO = "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
+	public final static String SECURITY_VERIFY_RESPONSE_SIGNATURE = "onelogin.saml2.security.verify_response_signature";
 
 	// Compress
 	public final static String COMPRESS_REQUEST = "onelogin.saml2.compress.request";
@@ -322,6 +323,10 @@ public class SettingsBuilder {
 		if (rejectUnsolicitedResponsesWithInResponseTo != null) {
 			saml2Setting.setRejectUnsolicitedResponsesWithInResponseTo(rejectUnsolicitedResponsesWithInResponseTo);
 		}
+
+		Boolean verifyRespSignature = loadBooleanProperty(SECURITY_VERIFY_RESPONSE_SIGNATURE);
+		if (verifyRespSignature != null)
+			saml2Setting.setVerifyResponseSignature(verifyRespSignature);
 	}
 
 	/**


### PR DESCRIPTION
In some cases one would like to parametrize SAML Response signature. Some SAML providers, e.g. Siteminder allow IDP configuration that does not sing SAML Responses. 
For such a case I've introduced new parameter in the "onelogin.saml.properties" configuration file with a name: "onelogin.saml2.security.verify_response_signature". Setting this parameter to false by adding the following line:
onelogin.saml2.security.verify_response_signature = true

to the onelogin.saml.properties file skips the SAML Response signature verification step in the validation process.