### PR TITLE
Bump the Jacoco plugin allowing JDK11 builds

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,7 +74,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.7.201606060606</version>
+				<version>0.8.2</version>
 				<configuration>
 					<propertyName>jacoco.agent.argLine</propertyName>
 				</configuration>

--- a/toolkit/pom.xml
+++ b/toolkit/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.7.201606060606</version>
+				<version>0.8.2</version>
 				<configuration>
 					<propertyName>jacoco.agent.argLine</propertyName>
 				</configuration>


### PR DESCRIPTION
The current version of the jacoco plugin causes build errors if building with JDK 11. Bumping to the latest works. I have tested this with Jdk 11 and jdk 8. I have been unsuccessful in my archaeological studies trying to locate a JDK7, so not been able to test against that. 