### PR TITLE
Implement basic, top-level exception handling class.

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/exception/Error.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/Error.java
@@ -1,8 +1,8 @@
 package com.onelogin.saml2.exception;
 
-public class Error extends Exception {
+public class Error extends SamlException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     public static final int SETTINGS_FILE_NOT_FOUND = 1;
     public static final int METADATA_SP_INVALID = 2;
@@ -11,14 +11,14 @@ public class Error extends Exception {
     public static final int SAML_LOGOUTREQUEST_INVALID = 5;
     public static final int SAML_LOGOUTRESPONSE_INVALID = 6;
     public static final int SAML_SINGLE_LOGOUT_NOT_SUPPORTED = 7;
-    
+
     private int errorCode;
-	
-	public Error(String message, int errorCode) {
-		super(message);
-		this.errorCode = errorCode;
-	}
-	
+
+    public Error(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
     public int getErrorCode() {
         return errorCode;
     }

--- a/core/src/main/java/com/onelogin/saml2/exception/SamlException.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/SamlException.java
@@ -1,0 +1,44 @@
+package com.onelogin.saml2.exception;
+
+/**
+ * Top-level exception class for the OneLogin SAML client.
+ */
+public class SamlException extends Exception {
+    
+    private static final long serialVersionUID = 1L;
+    
+    /**
+     * Construct a SamlException with the provided error message.
+     * 
+     * @param message 
+     *     The human-readable error message associated with this exception.
+     */
+    public SamlException(String message) {
+        super(message);
+    }
+    
+    /**
+     * Construct a SamlException with the provided cause for the exception.
+     * 
+     * @param cause
+     *     The upstream cause of this exception.
+     */
+    public SamlException(Throwable cause) {
+        super(cause);
+    }
+    
+    /**
+     * Construct a SamlException with the provided human-readable error message
+     * and upstream cause.
+     * 
+     * @param message
+     *     The human-readable error message associated with this exception.
+     * 
+     * @param cause 
+     *     The upstream cause associated with this exception.
+     */
+    public SamlException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/core/src/main/java/com/onelogin/saml2/exception/SettingsException.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/SettingsException.java
@@ -1,23 +1,23 @@
 package com.onelogin.saml2.exception;
 
-public class SettingsException extends Exception {
+public class SettingsException extends SamlException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     public static final int SETTINGS_INVALID_SYNTAX = 1;
     public static final int SETTINGS_INVALID = 2;
     public static final int CERT_NOT_FOUND = 3;
     public static final int PRIVATE_KEY_NOT_FOUND = 4;
-    public static final int PUBLIC_CERT_FILE_NOT_FOUND = 5;    
+    public static final int PUBLIC_CERT_FILE_NOT_FOUND = 5;
     public static final int PRIVATE_KEY_FILE_NOT_FOUND = 6;
-    
+
     private int errorCode;
-	
-	public SettingsException(String message, int errorCode) {
-		super(message);
-		this.errorCode = errorCode;
-	}
-	
+
+    public SettingsException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
     public int getErrorCode() {
         return errorCode;
     }

--- a/core/src/main/java/com/onelogin/saml2/exception/ValidationError.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/ValidationError.java
@@ -1,66 +1,66 @@
 package com.onelogin.saml2.exception;
 
-public class ValidationError extends Exception {
+public class ValidationError extends SamlException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	public static final int UNSUPPORTED_SAML_VERSION = 0;
-	public static final int MISSING_ID = 1;
-	public static final int WRONG_NUMBER_OF_ASSERTIONS = 2;
-	public static final int MISSING_STATUS = 3;
-	public static final int MISSING_STATUS_CODE = 4;
-	public static final int STATUS_CODE_IS_NOT_SUCCESS = 5;
-	public static final int WRONG_SIGNED_ELEMENT = 6;
-	public static final int ID_NOT_FOUND_IN_SIGNED_ELEMENT = 7;
-	public static final int DUPLICATED_ID_IN_SIGNED_ELEMENTS = 8;
-	public static final int INVALID_SIGNED_ELEMENT = 9;
-	public static final int DUPLICATED_REFERENCE_IN_SIGNED_ELEMENTS = 10;
-	public static final int UNEXPECTED_SIGNED_ELEMENTS = 11;
-	public static final int WRONG_NUMBER_OF_SIGNATURES_IN_RESPONSE = 12;
-	public static final int WRONG_NUMBER_OF_SIGNATURES_IN_ASSERTION = 13;
-	public static final int INVALID_XML_FORMAT = 14;
-	public static final int WRONG_INRESPONSETO = 15;
-	public static final int NO_ENCRYPTED_ASSERTION = 16;
-	public static final int NO_ENCRYPTED_NAMEID = 17;
-	public static final int MISSING_CONDITIONS = 18;
-	public static final int ASSERTION_TOO_EARLY = 19;
-	public static final int ASSERTION_EXPIRED = 20;
-	public static final int WRONG_NUMBER_OF_AUTHSTATEMENTS = 21;
-	public static final int NO_ATTRIBUTESTATEMENT = 22;
-	public static final int ENCRYPTED_ATTRIBUTES = 23;
-	public static final int WRONG_DESTINATION = 24;
-	public static final int EMPTY_DESTINATION = 25;
-	public static final int WRONG_AUDIENCE = 26;
-	public static final int ISSUER_MULTIPLE_IN_RESPONSE = 27;
-	public static final int ISSUER_NOT_FOUND_IN_ASSERTION = 28;
-	public static final int WRONG_ISSUER = 29;
-	public static final int SESSION_EXPIRED = 30;
-	public static final int WRONG_SUBJECTCONFIRMATION = 31;
-	public static final int NO_SIGNED_MESSAGE = 32;
-	public static final int NO_SIGNED_ASSERTION = 33;
-	public static final int NO_SIGNATURE_FOUND = 34;
-	public static final int KEYINFO_NOT_FOUND_IN_ENCRYPTED_DATA = 35;
-	public static final int CHILDREN_NODE_NOT_FOUND_IN_KEYINFO = 36;
-	public static final int UNSUPPORTED_RETRIEVAL_METHOD = 37;
-	public static final int NO_NAMEID = 38;
-	public static final int EMPTY_NAMEID = 39;
-	public static final int SP_NAME_QUALIFIER_NAME_MISMATCH = 40;
-	public static final int DUPLICATED_ATTRIBUTE_NAME_FOUND = 41;
-	public static final int INVALID_SIGNATURE = 42;
-	public static final int WRONG_NUMBER_OF_SIGNATURES = 43;
-	public static final int RESPONSE_EXPIRED = 44;
-	public static final int UNEXPECTED_REFERENCE = 45;
-	public static final int NOT_SUPPORTED = 46;
-	public static final int KEY_ALGORITHM_ERROR = 47;
-	public static final int MISSING_ENCRYPTED_ELEMENT = 48;
-    
+    public static final int UNSUPPORTED_SAML_VERSION = 0;
+    public static final int MISSING_ID = 1;
+    public static final int WRONG_NUMBER_OF_ASSERTIONS = 2;
+    public static final int MISSING_STATUS = 3;
+    public static final int MISSING_STATUS_CODE = 4;
+    public static final int STATUS_CODE_IS_NOT_SUCCESS = 5;
+    public static final int WRONG_SIGNED_ELEMENT = 6;
+    public static final int ID_NOT_FOUND_IN_SIGNED_ELEMENT = 7;
+    public static final int DUPLICATED_ID_IN_SIGNED_ELEMENTS = 8;
+    public static final int INVALID_SIGNED_ELEMENT = 9;
+    public static final int DUPLICATED_REFERENCE_IN_SIGNED_ELEMENTS = 10;
+    public static final int UNEXPECTED_SIGNED_ELEMENTS = 11;
+    public static final int WRONG_NUMBER_OF_SIGNATURES_IN_RESPONSE = 12;
+    public static final int WRONG_NUMBER_OF_SIGNATURES_IN_ASSERTION = 13;
+    public static final int INVALID_XML_FORMAT = 14;
+    public static final int WRONG_INRESPONSETO = 15;
+    public static final int NO_ENCRYPTED_ASSERTION = 16;
+    public static final int NO_ENCRYPTED_NAMEID = 17;
+    public static final int MISSING_CONDITIONS = 18;
+    public static final int ASSERTION_TOO_EARLY = 19;
+    public static final int ASSERTION_EXPIRED = 20;
+    public static final int WRONG_NUMBER_OF_AUTHSTATEMENTS = 21;
+    public static final int NO_ATTRIBUTESTATEMENT = 22;
+    public static final int ENCRYPTED_ATTRIBUTES = 23;
+    public static final int WRONG_DESTINATION = 24;
+    public static final int EMPTY_DESTINATION = 25;
+    public static final int WRONG_AUDIENCE = 26;
+    public static final int ISSUER_MULTIPLE_IN_RESPONSE = 27;
+    public static final int ISSUER_NOT_FOUND_IN_ASSERTION = 28;
+    public static final int WRONG_ISSUER = 29;
+    public static final int SESSION_EXPIRED = 30;
+    public static final int WRONG_SUBJECTCONFIRMATION = 31;
+    public static final int NO_SIGNED_MESSAGE = 32;
+    public static final int NO_SIGNED_ASSERTION = 33;
+    public static final int NO_SIGNATURE_FOUND = 34;
+    public static final int KEYINFO_NOT_FOUND_IN_ENCRYPTED_DATA = 35;
+    public static final int CHILDREN_NODE_NOT_FOUND_IN_KEYINFO = 36;
+    public static final int UNSUPPORTED_RETRIEVAL_METHOD = 37;
+    public static final int NO_NAMEID = 38;
+    public static final int EMPTY_NAMEID = 39;
+    public static final int SP_NAME_QUALIFIER_NAME_MISMATCH = 40;
+    public static final int DUPLICATED_ATTRIBUTE_NAME_FOUND = 41;
+    public static final int INVALID_SIGNATURE = 42;
+    public static final int WRONG_NUMBER_OF_SIGNATURES = 43;
+    public static final int RESPONSE_EXPIRED = 44;
+    public static final int UNEXPECTED_REFERENCE = 45;
+    public static final int NOT_SUPPORTED = 46;
+    public static final int KEY_ALGORITHM_ERROR = 47;
+    public static final int MISSING_ENCRYPTED_ELEMENT = 48;
+
     private int errorCode;
-	
-	public ValidationError(String message, int errorCode) {
-		super(message);
-		this.errorCode = errorCode;
-	}
-	
+
+    public ValidationError(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
     public int getErrorCode() {
         return errorCode;
     }

--- a/core/src/main/java/com/onelogin/saml2/exception/XMLEntityException.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/XMLEntityException.java
@@ -1,11 +1,11 @@
 package com.onelogin.saml2.exception;
 
-public class XMLEntityException extends Exception {
+public class XMLEntityException extends SamlException {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	public XMLEntityException(String message) {
-		super(message);
-	}
+    public XMLEntityException(String message) {
+        super(message);
+    }
 
 }


### PR DESCRIPTION
This is probably the first part in addressing #146 - this change very simply adds the `SamlException` class and changes the existing exception classes to inherit from this one, which should make those easier to catch without having to broadly capture the entire `Exception` range.

Future changes will be geared toward trying to reduce the number of methods that throw multiple exceptions and funnel as many as possible through this parent `SamlException` class.