### PR TITLE
corrected typo in SamlResponse error message

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -241,7 +241,7 @@ public class SamlResponse {
 				// EncryptedAttributes are not supported
 				NodeList encryptedAttributeNodes = this.queryAssertion("/saml:AttributeStatement/saml:EncryptedAttribute");
 				if (encryptedAttributeNodes.getLength() > 0) {
-					throw new ValidationError("There is an EncryptedAttribute in the Response and this SP not support them", ValidationError.ENCRYPTED_ATTRIBUTES);
+					throw new ValidationError("There is an EncryptedAttribute in the Response and this SP does not support them", ValidationError.ENCRYPTED_ATTRIBUTES);
 				}
 
 				// Check destination

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -1449,7 +1449,7 @@ public class AuthnResponseTest {
 		settings.setStrict(true);
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertFalse(samlResponse.isValid());
-		assertEquals("There is an EncryptedAttribute in the Response and this SP not support them", samlResponse.getError());
+		assertEquals("There is an EncryptedAttribute in the Response and this SP does not support them", samlResponse.getError());
 	}
 
 	/**


### PR DESCRIPTION
corrected typo in SamlResponse error message when receiving (unsupported) EncryptedAttribute. Also updated associated unit test.