### PR TITLE
Only check if the destination url starts with the current request url instead of using equals

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -1144,7 +1144,7 @@ public class SamlResponse {
 			if (destinationUrl != null) {
 				if (destinationUrl.isEmpty()) {
 					throw new ValidationError("The response has an empty Destination value", ValidationError.EMPTY_DESTINATION);
-				} else if (!destinationUrl.equals(currentUrl)) {
+				} else if (!destinationUrl.startsWith(currentUrl)) {
 					throw new ValidationError("The response was received at " + currentUrl + " instead of " + destinationUrl, ValidationError.WRONG_DESTINATION);
 				}
 			}


### PR DESCRIPTION
This change will allow query strings to be defined in query strings.

This pull request is trying to address this issue: 
[Add support to pass Destination validation if it has query string in URL so that SP could define endpoint URLs with query string](https://github.com/onelogin/java-saml/issues/212)
