### PR TITLE
Add NVD checker to travis build

### DIFF
--- a/.nvd-suppressions.xml
+++ b/.nvd-suppressions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
+
+</suppressions>

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
 #  - oraclejdk7 #It seems oraclejdk7 temp fail on Travis
 install: true
 after_success:
-  - mvn clean test org.jacoco:jacoco-maven-plugin:report org.eluder.coveralls:coveralls-maven-plugin:report
+  - mvn clean verify org.jacoco:jacoco-maven-plugin:report org.eluder.coveralls:coveralls-maven-plugin:report

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,24 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.owasp</groupId>
+				<artifactId>dependency-check-maven</artifactId>
+				<version>5.0.0-M1</version>
+				<configuration>
+					<failBuildOnCVSS>7</failBuildOnCVSS>
+					<suppressionFiles>
+						<suppressionFile>.nvd-suppressions.xml</suppressionFile>
+					</suppressionFiles>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					 </execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<slf4jVersion>1.7.12</slf4jVersion>
 		<junitVersion>4.12</junitVersion>
-		<logbackVersion>1.1.3</logbackVersion>
+		<logbackVersion>1.2.3</logbackVersion>
 		<apacheCommonsLangVersion>3.4</apacheCommonsLangVersion>
 	</properties>
 


### PR DESCRIPTION
Proposed changes to introduce [NVD checker](https://jeremylong.github.io/DependencyCheck/).

Related to issue #223 

I included an empty suppressions file for future use.
It is pretty easy to edit. A guide is here https://jeremylong.github.io/DependencyCheck/general/suppression.html
Also correct suppression tags can be copy pasted from the report the tool generates.

The false positive came from an old logback version that has a ServerSocketReceiver related vulnerability. I don't think OneLogin uses that feature, but I thought it would be best to just update the dependency.