### PR TITLE
Allow only multiple certs when checking idp settings.

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -7,12 +7,10 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-
 import com.onelogin.saml2.model.Contact;
 import com.onelogin.saml2.model.Organization;
 import com.onelogin.saml2.util.Constants;
@@ -828,7 +826,7 @@ public class Saml2Settings {
 			LOGGER.error(errorMsg);
 		}
 
-		if (this.getIdpx509cert() == null && !checkRequired(this.getIdpCertFingerprint())) {
+		if (!checkIdpx509certRequired() && !checkRequired(this.getIdpCertFingerprint())) {
 			errorMsg = "idp_cert_or_fingerprint_not_found_and_required";
 			errors.add(errorMsg);
 			LOGGER.error(errorMsg);			
@@ -841,6 +839,19 @@ public class Saml2Settings {
 		}
 
 		return errors;
+	}
+
+	/**
+	 * Auxiliary method to check Idp certificate is configured.
+	 * 
+	 * @return true if the Idp Certificate settings are valid
+	 */
+	private boolean checkIdpx509certRequired () {
+		if (this.getIdpx509cert() != null) {
+			return true;
+		}
+
+		return this.getIdpx509certMulti() != null && !this.getIdpx509certMulti().isEmpty();
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
@@ -1,21 +1,18 @@
 package com.onelogin.saml2.test.settings;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
-
+import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.List;
-
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-
 import com.onelogin.saml2.exception.Error;
 import com.onelogin.saml2.settings.Metadata;
 import com.onelogin.saml2.settings.Saml2Settings;
@@ -184,7 +181,22 @@ public class Saml2SettingsTest {
 		settingsErrors = settings.checkSettings();
 		assertTrue(settingsErrors.isEmpty());
 	}
-	
+
+	/**
+	 * Tests the checkIdpSettings method of the {@link Saml2Settings}
+	 * Case: Multiple certs defined.
+	 * 
+	 * @throws Exception
+	 * 
+	 * @see com.onelogin.saml2.settings.Saml2Settings#checkIdPSettings
+	 */
+	@Test
+	public void testCheckIdpMultipleCertSettings () throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min_idp_multicert.properties").build();
+		List<String> settingsErrors = settings.checkSettings();
+		assertTrue(settingsErrors.isEmpty());
+	}
+
 	/**
 	 * Tests the checkSettings method of the Saml2Settings
 	 * Case: No SP Errors

--- a/core/src/test/resources/config/config.min_idp_multicert.properties
+++ b/core/src/test/resources/config/config.min_idp_multicert.properties
@@ -1,0 +1,26 @@
+#  Service Provider Data that we are deploying
+#  Identifier of the SP entity  (must be a URI)
+onelogin.saml2.sp.entityid = http://localhost:8080/java-saml-jspsample/metadata.jsp
+# Specifies info about where and how the <AuthnResponse> message MUST be
+#  returned to the requester, in this case our SP.
+# URL Location where the <Response> from the IdP will be returned
+onelogin.saml2.sp.assertion_consumer_service.url = http://localhost:8080/java-saml-jspsample/acs.jsp
+
+# Specifies info about Logout service
+# URL Location where the <LogoutResponse> from the IdP will be returned or where to send the <LogoutRequest>
+onelogin.saml2.sp.single_logout_service.url = http://localhost:8080/java-saml-jspsample/sls.jsp
+
+# Identity Provider Data that we want connect with our SP
+# Identifier of the IdP entity  (must be a URI)
+onelogin.saml2.idp.entityid = http://idp.example.com/
+
+# SSO endpoint info of the IdP. (Authentication Request protocol)
+# URL Target of the IdP where the SP will send the Authentication Request Message
+onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesaml/saml2/idp/SSOService.php
+
+# SLO endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Request
+onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
+
+# Public Multiple x509 certificate of the IdP
+onelogin.saml2.idp.x509certMulti.0 = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----


### PR DESCRIPTION
In Idp configuration settings it was mandatory to have the property for `onelogin.saml2.idp.x509cert` even if it was configured multiple certificates.

This change allows defining only settings for multiple Idp certs when it is not necessary the key X509Cert.