### PR TITLE
add status for logout response

### DIFF
--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -821,7 +821,7 @@ public class Auth {
 
 				String inResponseTo = logoutRequest.id;
 				LogoutResponse logoutResponseBuilder = new LogoutResponse(settings, httpRequest);
-				logoutResponseBuilder.build(inResponseTo);
+				logoutResponseBuilder.build(inResponseTo, Constants.STATUS_SUCCESS);
 				lastResponse = logoutResponseBuilder.getLogoutResponseXml();
 
 				String samlLogoutResponse = logoutResponseBuilder.getEncodedLogoutResponse();


### PR DESCRIPTION
When returning Logout Response, there is no way to set the status. This PR adds the status field.