### PR TITLE
Expose validation exception in SamlResponse

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -974,7 +974,7 @@ public class SamlResponse {
 	}
 
 	/**
-	 * After execute a validation process, if fails this method returns the cause
+	 * After execute a validation process, if fails this method returns the Exception object
 	 *
 	 * @return the cause of the validation error
 	 */

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -83,7 +83,7 @@ public class SamlResponse {
 	/**
 	 * After validation, if it fails this property has the cause of the problem
 	 */ 
-	private String error;
+	private Exception validationException;
 
 	/**
 	 * Constructor to have a Response object fully built and ready to validate the saml response.
@@ -148,7 +148,7 @@ public class SamlResponse {
 	 * @return if the response is valid or not
 	 */
 	public boolean isValid(String requestId) {
-		error = null;
+		validationException = null;
 
 		try {
 			if (samlResponseDocument == null) {
@@ -311,9 +311,9 @@ public class SamlResponse {
 			LOGGER.debug("SAMLResponse validated --> {}", samlResponseString);
 			return true;
 		} catch (Exception e) {
-			error = e.getMessage();
+			validationException = e;
 			LOGGER.debug("SAMLResponse invalid --> {}", samlResponseString);
-			LOGGER.error(error);
+			LOGGER.error(validationException.getMessage());
 			return false;
 		}
 	}
@@ -964,13 +964,22 @@ public class SamlResponse {
 	/**
      * After execute a validation process, if fails this method returns the cause
      *
-     * @return the cause of the validation error 
+     * @return the cause of the validation error as a string
      */
 	public String getError() {
-		if (error != null) {
-			return error;
+		if (validationException != null) {
+			return validationException.getMessage();
 		}
 		return null;
+	}
+
+	/**
+	 * After execute a validation process, if fails this method returns the cause
+	 *
+	 * @return the cause of the validation error
+	 */
+	public Exception getValidationException() {
+		return validationException;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -98,7 +98,7 @@ public class LogoutRequest {
 	/**
 	 * After validation, if it fails this property has the cause of the problem
 	 */ 
-	private String error;
+	private Exception validationException;
 
 	/**
 	 * Constructs the LogoutRequest object.
@@ -366,7 +366,7 @@ public class LogoutRequest {
 	 * @throws Exception
      */
 	public Boolean isValid() throws Exception {
-		error = null;
+		validationException = null;
 
 		try {
 			if (this.logoutRequestString == null || logoutRequestString.isEmpty()) {
@@ -474,9 +474,9 @@ public class LogoutRequest {
 			LOGGER.debug("LogoutRequest validated --> " + logoutRequestString);
 		    return true;	
 		} catch (Exception e) {
-			error = e.getMessage();
+			validationException = e;
 			LOGGER.debug("LogoutRequest invalid --> " + logoutRequestString);
-			LOGGER.error(error);
+			LOGGER.error(validationException.getMessage());
 			return false;
 		}
 	}
@@ -737,8 +737,21 @@ public class LogoutRequest {
      * @return the cause of the validation error 
      */
 	public String getError() {
-		return error;
+		if (validationException != null) {
+			return validationException.getMessage();
+		}
+		return null;
 	}
+
+	/**
+	 * After execute a validation process, if fails this method returns the Exception object
+	 *
+	 * @return the cause of the validation error
+	 */
+	public Exception getValidationException() {
+		return validationException;
+	}
+
 
 	/**
 	 * @return the ID of the Logout Request

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -82,7 +82,7 @@ public class LogoutResponse {
 	/**
 	 * After validation, if it fails this property has the cause of the problem
 	 */
-	private String error;
+	private Exception validationException;
 
 	/**
 	 * Constructs the LogoutResponse object.
@@ -168,7 +168,7 @@ public class LogoutResponse {
      * @return if the SAML LogoutResponse is or not valid
      */
 	public Boolean isValid(String requestId) {
-		error = null;
+		validationException = null;
 
 		try {
 			if (this.logoutResponseDocument == null) {
@@ -270,9 +270,9 @@ public class LogoutResponse {
 			LOGGER.debug("LogoutRequest validated --> " + logoutResponseString);
 			return true;
 		} catch (Exception e) {
-			error = e.getMessage();
+			validationException = e;
 			LOGGER.debug("LogoutResponse invalid --> " + logoutResponseString);
-			LOGGER.error(error);
+			LOGGER.error(validationException.getMessage());
 			return false;
 		}
 	}
@@ -451,6 +451,18 @@ public class LogoutResponse {
      * @return the cause of the validation error
      */
 	public String getError() {
-		return error;
+		if (validationException != null) {
+			return validationException.getMessage();
+		}
+		return null;
+	}
+
+	/**
+	 * After execute a validation process, if fails this method returns the Exception object
+	 *
+	 * @return the cause of the validation error
+	 */
+	public Exception getValidationException() {
+		return validationException;
 	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -2804,7 +2804,7 @@ public class AuthnResponseTest {
 	}
 	
 	/**
-	 * Tests the getError method of SamlResponse
+	 * Tests the getError and getValidationException methods of SamlResponse
 	 *
 	 * @throws ValidationError
 	 * @throws SettingsException
@@ -2823,25 +2823,32 @@ public class AuthnResponseTest {
 		String samlResponseEncoded = Util.getFileAsString("data/responses/response4.xml.base64");
 		SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertNull(samlResponse.getError());
+		assertNull(samlResponse.getValidationException());
 		samlResponse.isValid();
 		assertThat(samlResponse.getError(), containsString("SAML Response must contain 1 Assertion."));
+		assertTrue(samlResponse.getValidationException() instanceof ValidationError);
 
 		settings.setStrict(false);
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		samlResponse.isValid();
 		assertThat(samlResponse.getError(), containsString("SAML Response must contain 1 Assertion."));
+		assertTrue(samlResponse.getValidationException() instanceof ValidationError);
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertNull(samlResponse.getError());
+		assertNull(samlResponse.getValidationException());
 		samlResponse.isValid();
 		assertNull(samlResponse.getError());
+		assertNull(samlResponse.getValidationException());
 
 		settings.setStrict(true);
 		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
 		assertNull(samlResponse.getError());
+		assertNull(samlResponse.getValidationException());
 		samlResponse.isValid();
 		assertNull(samlResponse.getError());
+		assertNull(samlResponse.getValidationException());
 	}
 
 	private String loadAndEncode(String path) throws Exception

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -812,7 +812,7 @@ public class LogoutRequestTest {
 	}
 
 	/**
-	 * Tests the getError method of LogoutRequest
+	 * Tests the getError and getValidationException methods of LogoutRequest
 	 *
 	 * @throws Exception 
 	 *
@@ -828,14 +828,18 @@ public class LogoutRequestTest {
 
 		LogoutRequest logoutRequest = new LogoutRequest(settings, httpRequest);
 		assertNull(logoutRequest.getError());
+		assertNull(logoutRequest.getValidationException());
 		logoutRequest.isValid();
 		assertThat(logoutRequest.getError(), containsString("The LogoutRequest was received at"));
+		assertTrue(logoutRequest.getValidationException() instanceof ValidationError);
 
 		settings.setStrict(false);
 		logoutRequest = new LogoutRequest(settings, httpRequest);
 		assertNull(logoutRequest.getError());
+		assertNull(logoutRequest.getValidationException());
 		logoutRequest.isValid();
 		assertNull(logoutRequest.getError());
+		assertNull(logoutRequest.getValidationException());
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlRequestEncoded) {

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.onelogin.saml2.exception.ValidationError;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
@@ -573,7 +574,7 @@ public class LogoutResponseTest {
 	}
 
 	/**
-	 * Tests the getError method of LogoutResponse
+	 * Tests the getError and getValidationException methods of LogoutResponse
 	 *
 	 * @throws IOException
 	 * @throws URISyntaxException
@@ -591,14 +592,18 @@ public class LogoutResponseTest {
 		HttpRequest httpRequest = newHttpRequest(requestURL, samlResponseEncoded);
 		LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertNull(logoutResponse.getError());
+		assertNull(logoutResponse.getValidationException());
 		logoutResponse.isValid();
 		assertThat(logoutResponse.getError(), containsString("The LogoutResponse was received at"));
+		assertTrue(logoutResponse.getValidationException() instanceof ValidationError);
 
 		settings.setStrict(false);
 		logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertNull(logoutResponse.getError());
+		assertNull(logoutResponse.getValidationException());
 		logoutResponse.isValid();
 		assertNull(logoutResponse.getError());
+		assertNull(logoutResponse.getValidationException());
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlResponseEncoded) {

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -134,6 +134,11 @@ public class Auth {
 	private String errorReason;
 
 	/**
+	 * Exception of the last error.
+	 */
+	private Exception validationException;
+
+	/**
 	 * The id of the last request (Authn or Logout) generated
 	 */
 	private String lastRequestId;
@@ -748,6 +753,7 @@ public class Auth {
 				LOGGER.error("processResponse error. invalid_response");
 				LOGGER.debug(" --> " + samlResponseParameter);
 				errorReason = samlResponse.getError();
+				validationException = samlResponse.getValidationException();
 			}
 		} else {
 			errors.add("invalid_binding");
@@ -790,6 +796,7 @@ public class Auth {
 				LOGGER.error("processSLO error. invalid_logout_response");
 				LOGGER.debug(" --> " + samlResponseParameter);
 				errorReason = logoutResponse.getError();
+				validationException = logoutResponse.getValidationException();
 			} else {
 				String status = logoutResponse.getStatus();
 				if (status == null || !status.equals(Constants.STATUS_SUCCESS)) {
@@ -812,6 +819,7 @@ public class Auth {
 				LOGGER.error("processSLO error. invalid_logout_request");
 				LOGGER.debug(" --> " + samlRequestParameter);
 				errorReason = logoutRequest.getError();
+				validationException = logoutRequest.getValidationException();
 			} else {
 				lastMessageId = logoutRequest.getId();
 				LOGGER.debug("processSLO success --> " + samlRequestParameter);
@@ -970,6 +978,13 @@ public class Auth {
 	 */
 	public String getLastErrorReason() {
 		return errorReason;
+	}
+
+	/**
+	 * @return the exception for the last error
+	 */
+	public Exception getLastValidationException() {
+		return validationException;
 	}
 
 	/**

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -713,6 +713,7 @@ public class AuthTest {
 		assertFalse(auth.getErrors().isEmpty());
 		assertTrue(auth.getErrors().contains("invalid_logout_request"));
 		assertThat(auth.getLastErrorReason(), containsString("The LogoutRequest was received at"));
+		assertTrue(auth.getLastValidationException() instanceof ValidationError);
 	}
 
 	/**
@@ -854,6 +855,7 @@ public class AuthTest {
 		expectedErrors.add("invalid_response");
 		assertEquals(expectedErrors, auth.getErrors());
 		assertEquals("SAML Response must contain 1 Assertion.", auth.getLastErrorReason());
+		assertTrue(auth.getLastValidationException() instanceof ValidationError);
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
 		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
@@ -867,6 +869,7 @@ public class AuthTest {
 		expectedErrors.add("invalid_response");
 		assertEquals(expectedErrors, auth2.getErrors());
 		assertThat(auth2.getLastErrorReason(), containsString("Invalid issuer in the Assertion/Response"));
+		assertTrue(auth2.getLastValidationException() instanceof ValidationError);
 
 		samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
 		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
@@ -877,6 +880,7 @@ public class AuthTest {
 		assertTrue(auth3.isAuthenticated());
 		assertTrue(auth3.getErrors().isEmpty());
 		assertNull(auth3.getLastErrorReason());
+		assertNull(auth3.getLastValidationException());
 	}
 
 	/**


### PR DESCRIPTION
Hi, we have a requirement in our product to take different actions based on the exact error with the SAML response (in our case, show the user different documentation pages on how they can fix the problem).

The best way I found to do this which doesn't rely on string matching was to expose the actual exception as in this PR, then use `ValidationException#getErrorCode` to drive the logic.

I have not updated any tests yet, but am happy to do that if you agree this is an acceptable change.