### PR TITLE
[Fix #283] Expose a new constructor for SamlResponse

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -86,6 +86,32 @@ public class SamlResponse {
 	 *
 	 * @param settings
 	 *              Saml2Settings object. Setting data
+	 * @param currentUrl
+	 *              URL of the current host + current view
+	 *
+	 * @param samlResponse
+	 *              A string containting the base64 encoded response from the IdP
+	 *
+	 *
+	 * @throws ValidationError
+	 * @throws SettingsException
+	 * @throws IOException
+	 * @throws SAXException
+	 * @throws ParserConfigurationException
+	 * @throws XPathExpressionException
+     *
+	 */
+	public SamlResponse(Saml2Settings settings, String currentUrl, String samlResponse) throws XPathExpressionException, ParserConfigurationException, SAXException, IOException, SettingsException, ValidationError {
+		this.settings = settings;
+		this.currentUrl = currentUrl;
+		loadXmlFromBase64(samlResponse);
+	}
+
+	/**
+	 * Constructor to have a Response object fully built and ready to validate the saml response.
+	 *
+	 * @param settings
+	 *              Saml2Settings object. Setting data
 	 * @param request
 	 *				the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
 	 *
@@ -98,12 +124,7 @@ public class SamlResponse {
      *
 	 */
 	public SamlResponse(Saml2Settings settings, HttpRequest request) throws XPathExpressionException, ParserConfigurationException, SAXException, IOException, SettingsException, ValidationError {
-		this.settings = settings;
-
-		if (request != null) {
-			currentUrl = request.getRequestURL();
-			loadXmlFromBase64(request.getParameter("SAMLResponse"));
-		}
+		this(settings, request.getRequestURL(), request.getParameter("SAMLResponse"));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -69,9 +69,37 @@ public class AuthnResponseTest {
 		DateTimeUtils.setCurrentMillisSystem();
 	}
 
-	
 	/**
-	 * Tests the constructor of SamlResponse
+	 * Tests the deconstructed constructor of SamlResponse
+	 *
+	 * @throws Error
+	 * @throws IOException
+	 * @throws ValidationError
+	 * @throws SettingsException
+	 * @throws SAXException
+	 * @throws ParserConfigurationException
+	 * @throws XPathExpressionException
+	 *
+	 * @see com.onelogin.saml2.authn.SamlResponse
+	 */
+	@Test
+	public void testDeconstructedConstructor() throws IOException, Error, XPathExpressionException, ParserConfigurationException, SAXException, SettingsException, ValidationError {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+
+		final String requestURL = "/";
+		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
+
+		SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(requestURL, samlResponseEncoded));
+		assertTrue(samlResponse instanceof SamlResponse);
+
+		samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
+		samlResponse = new SamlResponse(settings, requestURL, samlResponseEncoded);
+		assertTrue(samlResponse instanceof SamlResponse);
+	}
+
+
+	/**
+	 * Tests the httpRequest constructor of SamlResponse
 	 *
 	 * @throws Error
 	 * @throws IOException


### PR DESCRIPTION
The SamlResponse class is basically a function which needs settings, url,
and a saml-response. This commit adds a constructor which takes only those
parameters instead of wrapping them in a HttpRequest.