### PR TITLE
Support for unwrapping key via an HSM when decrypting the SAML assertion.

### DIFF
--- a/.nvd-suppressions.xml
+++ b/.nvd-suppressions.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
-
+    <suppress>
+        <notes></notes>
+        <filePath regex="true">.*\bmsal4j-1.6.1\.jar</filePath>
+        <cpe>cpe:/a:http_authentication_library_project:http_authentication_library</cpe>
+    </suppress>
+    <suppress>
+        <notes></notes>
+        <filePath regex="true">.*\boauth2-oidc-sdk-6.14\.jar</filePath>
+        <cpe>cpe:/a:openid:openid</cpe>
+    </suppress>
 </suppressions>

--- a/.nvd-suppressions.xml
+++ b/.nvd-suppressions.xml
@@ -1,13 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.2.xsd">
-    <suppress>
-        <notes></notes>
-        <filePath regex="true">.*\bmsal4j-1.6.1\.jar</filePath>
-        <cpe>cpe:/a:http_authentication_library_project:http_authentication_library</cpe>
-    </suppress>
-    <suppress>
-        <notes></notes>
-        <filePath regex="true">.*\boauth2-oidc-sdk-6.14\.jar</filePath>
-        <cpe>cpe:/a:openid:openid</cpe>
-    </suppress>
 </suppressions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,6 +67,20 @@
 			<artifactId>commons-codec</artifactId>
 			<version>1.15</version>
 		</dependency>
+
+		<!-- Azure Key Vault -->
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-security-keyvault-keys</artifactId>
+			<version>4.2.1</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.azure</groupId>
+			<artifactId>azure-identity</artifactId>
+			<version>1.0.9</version>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Objects;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
+
+import com.onelogin.saml2.model.hsm.HSM;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -78,7 +80,7 @@ public class SamlResponse {
 
 	/**
 	 * After validation, if it fails this property has the cause of the problem
-	 */ 
+	 */
 	private Exception validationException;
 
 	/**
@@ -156,7 +158,7 @@ public class SamlResponse {
 
 		NodeList encryptedAssertionNodes = samlResponseDocument.getElementsByTagNameNS(Constants.NS_SAML,"EncryptedAssertion");
 
-		if (encryptedAssertionNodes.getLength() != 0) {			
+		if (encryptedAssertionNodes.getLength() != 0) {
 			decryptedDocument = Util.copyDocument(samlResponseDocument);
 			encrypted = true;
 			decryptedDocument = this.decryptAssertion(decryptedDocument);
@@ -566,12 +568,12 @@ public class SamlResponse {
 	 * @throws XPathExpressionException
 	 * @throws ValidationError
      *
-     */	
+     */
 	public HashMap<String, List<String>> getAttributes() throws XPathExpressionException, ValidationError {
 		HashMap<String, List<String>> attributes = new HashMap<String, List<String>>();
 
 		NodeList nodes = this.queryAssertion("/saml:AttributeStatement/saml:Attribute");
-		
+
 		if (nodes.getLength() != 0) {
 			for (int i = 0; i < nodes.getLength(); i++) {
 				NamedNodeMap attrName = nodes.item(i).getAttributes();
@@ -579,7 +581,7 @@ public class SamlResponse {
 				if (attributes.containsKey(attName) && !settings.isAllowRepeatAttributeName()) {
 					throw new ValidationError("Found an Attribute element with duplicated Name", ValidationError.DUPLICATED_ATTRIBUTE_NAME_FOUND);
 				}
-				
+
 				NodeList childrens = nodes.item(i).getChildNodes();
 
 				List<String> attrValues = null;
@@ -605,7 +607,7 @@ public class SamlResponse {
 
 	/**
 	 * Returns the ResponseStatus object
-	 * 
+	 *
 	 * @return
 	 */
 	public SamlResponseStatus getResponseStatus() {
@@ -639,7 +641,7 @@ public class SamlResponse {
 	 *
 	 * @throws IllegalArgumentException
 	 *             if the response not contain status or if Unexpected XPath error
-	 * @throws ValidationError 
+	 * @throws ValidationError
 	 */
 	public static SamlResponseStatus getStatus(Document dom) throws ValidationError {
 		String statusXpath = "/samlp:Response/samlp:Status";
@@ -682,7 +684,7 @@ public class SamlResponse {
 	 * Gets the audiences.
 	 *
 	 * @return the audiences of the response
-	 * 
+	 *
 	 * @throws XPathExpressionException
 	 */
 	public List<String> getAudiences() throws XPathExpressionException {
@@ -706,8 +708,8 @@ public class SamlResponse {
 	 *
 	 * @return the issuers of the assertion/response
 	 *
-	 * @throws XPathExpressionException 
-	 * @throws ValidationError 
+	 * @throws XPathExpressionException
+	 * @throws ValidationError
 	 */
 	public List<String> getIssuers() throws XPathExpressionException, ValidationError {
 		List<String> issuers = new ArrayList<String>();
@@ -763,7 +765,7 @@ public class SamlResponse {
      *
      * @return the SessionIndex value
      *
-     * @throws XPathExpressionException 
+     * @throws XPathExpressionException
      */
     public String getSessionIndex() throws XPathExpressionException {
         String sessionIndex = null;
@@ -852,7 +854,7 @@ public class SamlResponse {
 
 			String responseTag = "{" + Constants.NS_SAMLP  + "}Response";
 			String assertionTag = "{" + Constants.NS_SAML + "}Assertion";
-			
+
 			if (!signedElement.equals(responseTag) && !signedElement.equals(assertionTag)) {
 				throw new ValidationError("Invalid Signature Element " + signedElement + " SAML Response rejected", ValidationError.WRONG_SIGNED_ELEMENT);
 			}
@@ -862,13 +864,13 @@ public class SamlResponse {
 			if (idNode == null || idNode.getNodeValue() == null || idNode.getNodeValue().isEmpty()) {
 				throw new ValidationError("Signed Element must contain an ID. SAML Response rejected", ValidationError.ID_NOT_FOUND_IN_SIGNED_ELEMENT);
 			}
-			
-			String idValue = idNode.getNodeValue();			
+
+			String idValue = idNode.getNodeValue();
 			if (verifiedIds.contains(idValue)) {
 				throw new ValidationError("Duplicated ID. SAML Response rejected", ValidationError.DUPLICATED_ID_IN_SIGNED_ELEMENTS);
 			}
 			verifiedIds.add(idValue);
-			
+
 			NodeList refNodes = Util.query(null, "ds:SignedInfo/ds:Reference", signNode);
 			if (refNodes.getLength() == 1) {
 				Node refNode = refNodes.item(0);
@@ -878,7 +880,7 @@ public class SamlResponse {
 					if (!sei.equals(idValue)) {
 						throw new ValidationError("Found an invalid Signed Element. SAML Response rejected", ValidationError.INVALID_SIGNED_ELEMENT);
 					}
-					
+
 					if (verifiedSeis.contains(sei)) {
 						throw new ValidationError("Duplicated Reference URI. SAML Response rejected", ValidationError.DUPLICATED_REFERENCE_IN_SIGNED_ELEMENTS);
 					}
@@ -958,7 +960,7 @@ public class SamlResponse {
 	 *
 	 * @return true if still valid
 	 *
-	 * @throws ValidationError 
+	 * @throws ValidationError
 	 */
 	public boolean validateTimestamps() throws ValidationError {
 		NodeList timestampNodes = samlResponseDocument.getElementsByTagNameNS("*", "Conditions");
@@ -1026,7 +1028,7 @@ public class SamlResponse {
 	 *				Xpath Expression
 	 *
 	 * @return the queried node
-	 * @throws XPathExpressionException 
+	 * @throws XPathExpressionException
 	 *
 	 */
 	private NodeList queryAssertion(String assertionXpath) throws XPathExpressionException {
@@ -1075,7 +1077,7 @@ public class SamlResponse {
      *
      * @param nameQuery
      *				Xpath Expression
-     * @param context 
+     * @param context
      *              The context node
      *
      * @return DOMNodeList The queried nodes
@@ -1094,13 +1096,13 @@ public class SamlResponse {
 
 	/**
 	 * Decrypt assertion.
-	 * 
+	 *
 	 * @param dom
 	 *            Encrypted assertion
 	 *
 	 * @return Decrypted Assertion.
 	 *
-	 * @throws XPathExpressionException 
+	 * @throws XPathExpressionException
 	 * @throws IOException
 	 * @throws SAXException
 	 * @throws ParserConfigurationException
@@ -1110,7 +1112,9 @@ public class SamlResponse {
 	private Document decryptAssertion(Document dom) throws XPathExpressionException, ParserConfigurationException, SAXException, IOException, SettingsException, ValidationError {
 		PrivateKey key = settings.getSPkey();
 
-		if (key == null) {
+		HSM hsm = this.settings.getHsm();
+
+		if (hsm == null && key == null) {
 			throw new SettingsException("No private key available for decrypt, check settings", SettingsException.PRIVATE_KEY_NOT_FOUND);
 		}
 
@@ -1119,7 +1123,13 @@ public class SamlResponse {
 		    throw new ValidationError("No /samlp:Response/saml:EncryptedAssertion/xenc:EncryptedData element found", ValidationError.MISSING_ENCRYPTED_ELEMENT);
 		}
 		Element encryptedData = (Element) encryptedDataNodes.item(0);
-		Util.decryptElement(encryptedData, key);
+
+		if (hsm != null) {
+			Util.decryptUsingHsm(encryptedData, hsm);
+		} else {
+			Util.decryptElement(encryptedData, key);
+		}
+
 
 		// We need to Remove the saml:EncryptedAssertion Node
 		NodeList AssertionDataNodes = Util.query(dom, "/samlp:Response/saml:EncryptedAssertion/saml:Assertion");
@@ -1138,7 +1148,7 @@ public class SamlResponse {
 	}
 
 	/**
-	 * @return the SAMLResponse XML, If the Assertion of the SAMLResponse was encrypted,  
+	 * @return the SAMLResponse XML, If the Assertion of the SAMLResponse was encrypted,
 	 *         returns the XML with the assertion decrypted
 	 */
 	public String getSAMLResponseXml() {
@@ -1148,11 +1158,11 @@ public class SamlResponse {
 		} else {
 			xml = samlResponseString;
 		}
-		return xml; 
+		return xml;
 	}
 
 	/**
-	 * @return the SAMLResponse Document, If the Assertion of the SAMLResponse was encrypted,  
+	 * @return the SAMLResponse Document, If the Assertion of the SAMLResponse was encrypted,
 	 *         returns the Document with the assertion decrypted
 	 */
 	protected Document getSAMLResponseDocument() {

--- a/core/src/main/java/com/onelogin/saml2/model/hsm/AzureKeyVault.java
+++ b/core/src/main/java/com/onelogin/saml2/model/hsm/AzureKeyVault.java
@@ -1,0 +1,139 @@
+package com.onelogin.saml2.model.hsm;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
+import com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm;
+import com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm;
+import com.onelogin.saml2.util.Constants;
+
+import java.util.HashMap;
+
+public class AzureKeyVault extends HSM {
+
+	private String clientId;
+	private String clientCredentials;
+	private String tenantId;
+	private String keyVaultId;
+	private CryptographyClient akvClient;
+	private HashMap<String, KeyWrapAlgorithm> algorithmMapping;
+
+	/**
+	 * Constructor to initialise an HSM object.
+	 *
+	 * @param clientId          The Azure Key Vault client ID.
+	 * @param clientCredentials The Azure Key Vault client credentials.
+	 * @param tenantId          The Azure Key Vault tenant ID.
+	 * @param keyVaultId        The Azure Key Vault ID.
+	 * @return AzureKeyVault
+	 */
+	public AzureKeyVault(String clientId, String clientCredentials, String tenantId, String keyVaultId) {
+		this.clientId = clientId;
+		this.clientCredentials = clientCredentials;
+		this.tenantId = tenantId;
+		this.keyVaultId = keyVaultId;
+
+		this.algorithmMapping = createAlgorithmMapping();
+	}
+
+	/**
+	 * Creates a mapping between the URLs received from the encrypted SAML
+	 * assertion and the algorithms as how they are expected to be received from
+	 * the Azure Key Vault.
+	 *
+	 * @return The algorithm mapping.
+	 */
+	private HashMap<String, KeyWrapAlgorithm> createAlgorithmMapping() {
+		HashMap<String, KeyWrapAlgorithm> mapping = new HashMap<>();
+
+		mapping.put(Constants.RSA_1_5, KeyWrapAlgorithm.RSA1_5);
+		mapping.put(Constants.RSA_OAEP_MGF1P, KeyWrapAlgorithm.RSA_OAEP);
+		mapping.put(Constants.A128KW, KeyWrapAlgorithm.A128KW);
+		mapping.put(Constants.A192KW, KeyWrapAlgorithm.A192KW);
+		mapping.put(Constants.A256KW, KeyWrapAlgorithm.A256KW);
+
+		return mapping;
+	}
+
+	/**
+	 * Retrieves the key wrap algorithm object based on the algorithm URL passed
+	 * within the SAML assertion.
+	 *
+	 * @param algorithmUrl The algorithm URL.
+	 * @return The KeyWrapAlgorithm.
+	 */
+	private KeyWrapAlgorithm getAlgorithm(String algorithmUrl) {
+		return algorithmMapping.get(algorithmUrl);
+	}
+
+	/**
+	 * Sets the client to connect to the Azure Key Vault.
+	 */
+	@Override
+	public void setClient() {
+		ClientSecretCredential clientSecretCredential = new ClientSecretCredentialBuilder()
+			.clientId(clientId)
+			.clientSecret(clientCredentials)
+			.tenantId(tenantId)
+			.build();
+
+		HttpClient httpClient = new NettyAsyncHttpClientBuilder().build();
+
+		this.akvClient = new CryptographyClientBuilder()
+			.httpClient(httpClient)
+			.credential(clientSecretCredential)
+			.keyIdentifier(keyVaultId)
+			.buildClient();
+	}
+
+	/**
+	 * Wraps a key with a particular algorithm using the Azure Key Vault.
+	 *
+	 * @param algorithm The algorithm to use to wrap the key.
+	 * @param key       The key to wrap
+	 * @return A wrapped key.
+	 */
+	@Override
+	public byte[] wrapKey(String algorithm, byte[] key) {
+		return this.akvClient.wrapKey(KeyWrapAlgorithm.fromString(algorithm), key).getEncryptedKey();
+	}
+
+	/**
+	 * Unwraps a key with a particular algorithm using the Azure Key Vault.
+	 *
+	 * @param algorithmUrl The algorithm to use to unwrap the key.
+	 * @param wrappedKey   The key to unwrap
+	 * @return An unwrapped key.
+	 */
+	@Override
+	public byte[] unwrapKey(String algorithmUrl, byte[] wrappedKey) {
+		return this.akvClient.unwrapKey(getAlgorithm(algorithmUrl), wrappedKey).getKey();
+	}
+
+	/**
+	 * Encrypts an array of bytes with a particular algorithm using the Azure Key Vault.
+	 *
+	 * @param algorithm The algorithm to use for encryption.
+	 * @param plainText The array of bytes to encrypt.
+	 * @return An encrypted array of bytes.
+	 */
+	@Override
+	public byte[] encrypt(String algorithm, byte[] plainText) {
+		return this.akvClient.encrypt(EncryptionAlgorithm.fromString(algorithm), plainText).getCipherText();
+	}
+
+	/**
+	 * Decrypts an array of bytes with a particular algorithm using the Azure Key Vault.
+	 *
+	 * @param algorithm  The algorithm to use for decryption.
+	 * @param cipherText The encrypted array of bytes.
+	 * @return A decrypted array of bytes.
+	 */
+	@Override
+	public byte[] decrypt(String algorithm, byte[] cipherText) {
+		return this.akvClient.decrypt(EncryptionAlgorithm.fromString(algorithm), cipherText).getPlainText();
+	}
+}

--- a/core/src/main/java/com/onelogin/saml2/model/hsm/HSM.java
+++ b/core/src/main/java/com/onelogin/saml2/model/hsm/HSM.java
@@ -1,0 +1,44 @@
+package com.onelogin.saml2.model.hsm;
+
+public abstract class HSM {
+	/**
+	 * Sets the client to connect to the Azure Key Vault.
+	 */
+	public abstract void setClient();
+
+	/**
+	 * Wraps a key with a particular algorithm using the HSM
+	 *
+	 * @param algorithm The algorithm to use to wrap the key.
+	 * @param key       The key to wrap
+	 * @return A wrapped key.
+	 */
+	public abstract byte[] wrapKey(String algorithm, byte[] key);
+
+	/**
+	 * Unwraps a key with a particular algorithm using the HSM.
+	 *
+	 * @param algorithmUrl  The algorithm URL to use to unwrap the key.
+	 * @param wrappedKey The key to unwrap
+	 * @return An unwrapped key.
+	 */
+	public abstract byte[] unwrapKey(String algorithmUrl, byte[] wrappedKey);
+
+	/**
+	 * Encrypts an array of bytes with a particular algorithm using the HSM.
+	 *
+	 * @param algorithm The algorithm to use for encryption.
+	 * @param plainText The array of bytes to encrypt.
+	 * @return An encrypted array of bytes.
+	 */
+	public abstract byte[] encrypt(String algorithm, byte[] plainText);
+
+	/**
+	 * Decrypts an array of bytes with a particular algorithm using the HSM.
+	 *
+	 * @param algorithm  The algorithm to use for decryption.
+	 * @param cipherText The encrypted array of bytes.
+	 * @return A decrypted array of bytes.
+	 */
+	public abstract byte[] decrypt(String algorithm, byte[] cipherText);
+}

--- a/core/src/main/java/com/onelogin/saml2/util/Constants.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Constants.java
@@ -110,6 +110,9 @@ public final class Constants {
 	public static String AES128_CBC = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
 	public static String AES192_CBC = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
 	public static String AES256_CBC = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+	public static String A128KW = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+	public static String A192KW = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+	public static String A256KW = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
 	public static String RSA_1_5 = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
 	public static String RSA_OAEP_MGF1P = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
 	

--- a/core/src/test/resources/config/config.hsm.properties
+++ b/core/src/test/resources/config/config.hsm.properties
@@ -1,0 +1,26 @@
+#  Service Provider Data that we are deploying
+#  Identifier of the SP entity  (must be a URI)
+onelogin.saml2.sp.entityid = http://localhost:8080/java-saml-jspsample/metadata.jsp
+# Specifies info about where and how the <AuthnResponse> message MUST be
+#  returned to the requester, in this case our SP.
+# URL Location where the <Response> from the IdP will be returned
+onelogin.saml2.sp.assertion_consumer_service.url = http://localhost:8080/java-saml-jspsample/acs.jsp
+
+# Specifies info about Logout service
+# URL Location where the <LogoutResponse> from the IdP will be returned or where to send the <LogoutRequest>
+onelogin.saml2.sp.single_logout_service.url = http://localhost:8080/java-saml-jspsample/sls.jsp
+
+# Identity Provider Data that we want connect with our SP
+# Identifier of the IdP entity  (must be a URI)
+onelogin.saml2.idp.entityid = http://idp.example.com/
+
+# SSO endpoint info of the IdP. (Authentication Request protocol)
+# URL Target of the IdP where the SP will send the Authentication Request Message
+onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesaml/saml2/idp/SSOService.php
+
+# SLO endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Request
+onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
+
+# Public x509 certificate of the IdP
+onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 			<plugin>
 				<groupId>org.owasp</groupId>
 				<artifactId>dependency-check-maven</artifactId>
-				<version>6.0.2</version>
+				<version>6.0.3</version>
 				<configuration>
 					<failBuildOnCVSS>7</failBuildOnCVSS>
 					<suppressionFiles>

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -291,7 +291,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.sperrors.properties").build();
 		
 		expectedEx.expect(SettingsException.class);
-		expectedEx.expectMessage("Invalid settings: sp_entityId_not_found, sp_acs_not_found, sp_cert_not_found_and_required, contact_not_enought_data, organization_not_enought_data, idp_cert_or_fingerprint_not_found_and_required, idp_cert_not_found_and_required");
+		expectedEx.expectMessage("Invalid settings: sp_entityId_not_found, sp_acs_not_found, sp_cert_not_found_and_required, contact_not_enough_data, organization_not_enough_data, idp_cert_or_fingerprint_not_found_and_required, idp_cert_not_found_and_required");
 		new Auth(settings, request, response);
 	}
 


### PR DESCRIPTION
This pull request addresses [#257](https://github.com/onelogin/java-saml/issues/257)

Currently, the library has no support for HSM integration, in particular when it comes to unwrap the key as part of the SAML decryption process.

Hence, this solution will support HSM key unwrapping by setting an HSM object as part of the SAML settings. My requirement was to integrate this library specifically to the Azure Key Vault. However, I have implemented an HSM abstract class in order to allow the possibility of integrating it with other HSMs as well. I have also imported 2 new libraries (for the Azure Key Vault) as optional dependencies since whoever is going to use this library might not require this HSM support. 

I have also upgraded the dependency check plugin to the current latest version (v6.0.3) since it includes fixes of the false positives which were flagged when those 2 new libraries were imported.