### PR TITLE
Check request method to determine correct response binding

### DIFF
--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -5,13 +5,11 @@ import com.onelogin.saml2.exception.Error;
 import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.http.HttpRequest;
-import com.onelogin.saml2.logout.LogoutRequest;
 import com.onelogin.saml2.model.SamlResponseStatus;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
-
 import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
@@ -27,6 +25,8 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,9 +37,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPathExpressionException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
@@ -3027,7 +3024,7 @@ public class AuthnResponseTest {
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlResponseEncoded) {
-		return new HttpRequest(requestURL, (String)null).addParameter("SAMLResponse", samlResponseEncoded);
+		return new HttpRequest("GET", requestURL, (String)null).addParameter("SAMLResponse", samlResponseEncoded);
 	}
 	
 	private void setDateTime(String ISOTimeStamp) {

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -664,7 +664,7 @@ public class LogoutRequestTest {
 		//This signature is based on the query string above
 		String signature = "cxDTcLRHhXJKGYcjZE2RRz5p7tVg/irNimq48KkJ0n10wiGwAmuzUByxEm4OHbetDrHGtxI5ygjrR0/HcrD8IkYyI5Ie4r5tJYkfdtpUrvOQ7khbBvP9GzEbZIrz7eH1ALdCDchORaRB/cs6v+OZbBj5uPTrN//wOhZl2k9H2xVW/SYy17jDoIKh/wvqtQ9FF+h2UxdUEhxeB/UUXOC6nVLMo+RGaamSviYkUE1Zu1tmalO+F6FivNQ31T/TkqzWz0KEjmnFs3eKbHakPVuUHpDQm7Gf2gBS1TXwVQsL7e2axtvv4RH5djlq1Z2WH2V+PwGOkIvLxf3igGUSR1A8bw==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, queryString)
 				.addParameter("SAMLRequest", samlRequestEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -692,7 +692,7 @@ public class LogoutRequestTest {
 		//This signature is based on the query string above
 		String signatureNaiveEncoding = "Gj2mUq6RBPAPXI9VjDDlwAxueSEBlOfgpWKLpsQbqIp+2XPFtC/vPAZpuPjHCDNNnAI3WKZa4l8ijwQBTqQwKz88k9gTx6vcLxPl2L4SrWdLOokiGrIVYJ+0sK2hapHHMa7WzGiTgpeTuejHbD4ptneaRXl4nrJAEo0WJ/rNTSWbJpnb+ENtgBnsfkmj+6z1KFY70ruo7W/vme21Jg+4XNfBSGl6LLSjEnZHJG0ET80HKvJEZayv4BQGZ3MShcSMyab/w+rLfDvDRA5RcRxw+NHOXo/kxZ3qhpa6daOwG69+PiiWmusmB2gaSq6jy2L55zFks9a36Pt5l5fYA2dE4g==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, queryString)
 				.addParameter("SAMLRequest", samlRequestEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -721,7 +721,7 @@ public class LogoutRequestTest {
 		String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 		String signature = "XCwCyI5cs7WhiJlB5ktSlWxSBxv+6q2xT3c8L7dLV6NQG9LHWhN7gf8qNsahSXfCzA0Ey9dp5BQ0EdRvAk2DIzKmJY6e3hvAIEp1zglHNjzkgcQmZCcrkK9Czi2Y1WkjOwR/WgUTUWsGJAVqVvlRZuS3zk3nxMrLH6f7toyvuJc=";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, (String)null)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, (String)null)
 						.addParameter("SAMLRequest", samlRequestEncoded)
 						.addParameter("RelayState", relayState)
 						.addParameter("SigAlg", sigAlg)
@@ -786,7 +786,7 @@ public class LogoutRequestTest {
 		String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 		String signature = "XCwCyI5cs7WhiJlB5ktSlWxSBxv+6q2xT3c8L7dLV6NQG9LHWhN7gf8qNsahSXfCzA0Ey9dp5BQ0EdRvAk2DIzKmJY6e3hvAIEp1zglHNjzkgcQmZCcrkK9Czi2Y1WkjOwR/WgUTUWsGJAVqVvlRZuS3zk3nxMrLH6f7toyvuJc=";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, (String)null)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, (String)null)
 						.addParameter("SAMLRequest", samlRequestEncoded)
 						.addParameter("RelayState", relayState)
 						.addParameter("SigAlg", sigAlg)
@@ -877,6 +877,6 @@ public class LogoutRequestTest {
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlRequestEncoded) {
-		return new HttpRequest(requestURL, (String)null).addParameter("SAMLRequest", samlRequestEncoded);
+		return new HttpRequest("GET", requestURL, (String)null).addParameter("SAMLRequest", samlRequestEncoded);
 	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -41,7 +41,7 @@ public class LogoutResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		final String logoutResponseString = Util.getFileAsString("data/logout_responses/logout_response.xml");
 		final String requestURL = "/";
-		HttpRequest httpRequest = new HttpRequest(requestURL, (String)null);
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, (String)null);
 
 		LogoutResponse logoutResponseBuilder = new LogoutResponse(settings, httpRequest) {
 			@Override
@@ -137,7 +137,7 @@ public class LogoutResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		final String requestURL = "/";
-		HttpRequest httpRequest = new HttpRequest(requestURL, (String)null);
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, (String)null);
 
 		LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertFalse(logoutResponse.isValid());
@@ -266,7 +266,7 @@ public class LogoutResponseTest {
 		assertFalse(logoutResponse.isValid());
 		assertEquals("SAML Logout Response is not loaded", logoutResponse.getError());
 
-		httpRequest = new HttpRequest(requestURL, (String)null);
+		httpRequest = new HttpRequest("GET", requestURL, (String)null);
 		logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertFalse(logoutResponse.isValid());
 		assertEquals("SAML Logout Response is not loaded", logoutResponse.getError());
@@ -449,7 +449,7 @@ public class LogoutResponseTest {
 		//This signature is based on the query string above
 		String signature = "czxEy2WDRZS1U4b2PQFpE4KRhRs8jt5bBKdTFx5oIXpte6qtm0Lk/5lzw/2S6Y1NJpj5DJvSLJvylgNE+RYfJR1GX0zQplm2dZYtlo7CZUyfS3JCLsWviEtPXaon+8Z0lQQkPt4yxCf9v8Qd0pvxHglTUCK/sU0NXnZQdpSxxfsaNCcjQf5gTg/gj8oI7xdrnamBPFtsaH6tAirkjGMoYS4Otju3mcrdcNBIHG40wrffUDnE83Jw4AOFCp8Vsf0zPTQOQsxS4HF4VS78OvGn7jLi2MdabeAQcK5+tP3mUB4vO8AAt8QbkEEiWQbcvA9i1Ezma92CdNYgaf4B3JYpPA==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, queryString)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -477,7 +477,7 @@ public class LogoutResponseTest {
 		//This signature is based on the query string above
 		String signature = "eSoTB+0GA/HfncASEFk7ONHbB3+9YrOBgK9xUyRoCDY97oXw49JYoXOL07kHrVvbngKmKFNx5fnYtDaL8WCe5LfRRgjJz1LLacriHn2ggeMmY/fTaXPoy2zQW0Fv1H362QXicTWQXgWFS5cJAIcBa2I7TLgNwXsMgjdBF2hyacW0IwfkAceGiBwDDTy6XIBAZk2Ff7w5lbZh+fa5JLNKrbvoveJk2NS3KK6INYO7UW5hukWz2cpzbHsx9lfxUJi8/ZCwUtFWZ4rdXVN+Qiw5y8S2eE2BIEfFmz7IfvrMRXa2la/rXFQfmteQo+N1sO3K1YZyoT/aA3k36glXvnj3kw==";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, queryString)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, queryString)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -509,7 +509,7 @@ public class LogoutResponseTest {
 		String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 		String signature = "vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA=";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, (String)null)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, (String)null)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -575,7 +575,7 @@ public class LogoutResponseTest {
 		String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
 		String signature = "vfWbbc47PkP3ejx4bjKsRX7lo9Ml1WRoE5J5owF/0mnyKHfSY6XbhO1wwjBV5vWdrUVX+xp6slHyAf4YoAsXFS0qhan6txDiZY4Oec6yE+l10iZbzvie06I4GPak4QrQ4gAyXOSzwCrRmJu4gnpeUxZ6IqKtdrKfAYRAcVfNKGA=";
 
-		HttpRequest httpRequest = new HttpRequest(requestURL, (String)null)
+		HttpRequest httpRequest = new HttpRequest("GET", requestURL, (String)null)
 				.addParameter("SAMLResponse", samlResponseEncoded)
 				.addParameter("RelayState", relayState)
 				.addParameter("SigAlg", sigAlg)
@@ -644,6 +644,6 @@ public class LogoutResponseTest {
 	}
 
 	private static HttpRequest newHttpRequest(String requestURL, String samlResponseEncoded) {
-		return new HttpRequest(requestURL, (String)null).addParameter("SAMLResponse", samlResponseEncoded);
+		return new HttpRequest("GET", requestURL, (String)null).addParameter("SAMLResponse", samlResponseEncoded);
 	}
 }

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -869,8 +869,19 @@ public class Auth {
 	public String processSLO(Boolean keepLocalSession, String requestId, Boolean stay) throws Exception {
 		final HttpRequest httpRequest = ServletUtils.makeHttpRequest(this.request);
 
-		final String samlRequestParameter = httpRequest.getParameter("SAMLRequest");
-		final String samlResponseParameter = httpRequest.getParameter("SAMLResponse");
+		final String samlRequestParameter;
+		final String samlResponseParameter;
+
+		if (httpRequest.isGet()) {
+			samlRequestParameter = httpRequest.getParameter("SAMLRequest");
+			samlResponseParameter = httpRequest.getParameter("SAMLResponse");
+		} else {
+			// NOTE: even if the request method is POST, it's possible that parameters were sent in the
+			// URL; however the Redirect binding requires a GET, so we basically use this as a mechanism
+			// to fail the processing on non-GET requests all together. See #299.
+			samlRequestParameter = null;
+			samlResponseParameter = null;
+		}
 
 		if (samlResponseParameter != null) {
 			LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);

--- a/toolkit/src/main/java/com/onelogin/saml2/servlet/ServletUtils.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/servlet/ServletUtils.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.onelogin.saml2.http.HttpRequest;
 import com.onelogin.saml2.util.Util;
 
@@ -32,14 +30,13 @@ public class ServletUtils {
      * @return a HttpRequest
      */
     public static HttpRequest makeHttpRequest(HttpServletRequest req) {
-    	@SuppressWarnings("unchecked")
-        final Map<String, String[]> paramsAsArray = (Map<String, String[]>) req.getParameterMap();
+        final Map<String, String[]> paramsAsArray = req.getParameterMap();
         final Map<String, List<String>> paramsAsList = new HashMap<>();
         for (Map.Entry<String, String[]> param : paramsAsArray.entrySet()) {
             paramsAsList.put(param.getKey(), Arrays.asList(param.getValue()));
         }
 
-        return new HttpRequest(req.getRequestURL().toString(), paramsAsList, req.getQueryString());
+        return new HttpRequest(req.getMethod(), req.getRequestURL().toString(), paramsAsList, req.getQueryString());
     }
 
     /**
@@ -52,7 +49,7 @@ public class ServletUtils {
      * @return the HOST URL
      */
     public static String getSelfURLhost(HttpServletRequest request) {
-        String hostUrl = StringUtils.EMPTY;
+        String hostUrl;
         final int serverPort = request.getServerPort();
         if ((serverPort == 80) || (serverPort == 443) || serverPort == 0) {
             hostUrl = String.format("%s://%s", request.getScheme(), request.getServerName());

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -7,10 +7,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.mock;
@@ -626,7 +628,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestKeepSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -655,7 +657,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestRemoveSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -683,7 +685,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestStay() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -711,7 +713,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestStayFalse() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -741,7 +743,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestStayTrue() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -762,6 +764,36 @@ public class AuthTest {
 
 	/**
 	 * Tests the processSLO methods of Auth
+	 * Case: message delivered over incorrect HTTP method (implying wrong binding is used)
+	 *
+	 * @throws Exception
+	 *
+	 * @see com.onelogin.saml2.Auth#processSLO
+	 */
+	@Test
+	public void testProcessSLOWrongMethod() throws Exception {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		HttpSession session = mock(HttpSession.class);
+		when(request.getMethod()).thenReturn("post");
+		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
+		when(request.getSession()).thenReturn(session);
+
+		Map<String, String[]> params = new HashMap<>();
+		params.put("SAMLRequest", new String[]{"doesnt-matter"});
+		params.put("SAMLResponse", new String[]{"ditto"});
+
+		when(request.getParameterMap()).thenReturn(params);
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		Auth auth = new Auth(settings, request, response);
+		assertFalse(auth.isAuthenticated());
+		assertTrue(auth.getErrors().isEmpty());
+		assertThrows(Error.class, ()->auth.processSLO(false, null, true));
+		assertThat(auth.getErrors().get(0), equalTo("invalid_binding"));
+	}
+
+	/**
+	 * Tests the processSLO methods of Auth
 	 * Case: process LogoutRequest, with RelayState and sign response
 	 *
 	 * @throws Exception
@@ -770,7 +802,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestSignRes() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -806,7 +838,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLORequestInvalid() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/java-saml-jspsample/sls.jsp"));
@@ -837,7 +869,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseKeepSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -864,7 +896,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseRemoveSession() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -891,7 +923,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseWrongRequestId() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -920,7 +952,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testProcessSLOResponseStatusResponder() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		HttpSession session = mock(HttpSession.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
@@ -2123,7 +2155,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutRequestReceived() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("/"));
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request.xml.base64");
@@ -2177,7 +2209,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutResponseSent() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("http://stuff.com/endpoints/endpoints/sls.php"));
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
@@ -2201,7 +2233,7 @@ public class AuthTest {
 	 */
 	@Test
 	public void testGetLastLogoutResponseReceived() throws Exception {
-		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletRequest request = mockGet();
 		HttpServletResponse response = mock(HttpServletResponse.class);
 		when(request.getRequestURL()).thenReturn(new StringBuffer("/"));
 		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response.xml.base64");
@@ -2213,4 +2245,11 @@ public class AuthTest {
 		String logoutResponseXML =  auth.getLastResponseXML();
 		assertThat(logoutResponseXML, containsString("<samlp:LogoutResponse"));
 	}
+
+	private HttpServletRequest mockGet() {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getMethod()).thenReturn("GET");
+		return request;
+	}
+
 }


### PR DESCRIPTION
This is a bit more extensive than I expected, but an alternative would be hackier.
Let me know if you need me to change anything, but IMHO, holding the incoming method in the framework's http request representation is right, and will be useful once #113 is implemented.