### PR TITLE
Add support for multiple Attribute Consuming Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ onelogin.saml2.sp.x509certNew =
 # If you have     PKCS#1   BEGIN RSA PRIVATE KEY  convert it by   openssl pkcs8 -topk8 -inform pem -nocrypt -in sp.rsa_key -outform pem -out sp.pem
 onelogin.saml2.sp.privatekey =
 
+# Attribute Consuming Services
+# SEE BELOW
+
 ## Identity Provider Data that we want connect with our SP ##
 
 # Identifier of the IdP entity  (must be a URI)
@@ -476,9 +479,88 @@ The getSPMetadata will return the metadata signed or not based on the security p
 
 Before the XML metadata is exposed, a check takes place to ensure that the info to be provided is valid.
 
-##### Attribute Consumer Service(ACS)
-This code handles the SAML response that the IdP forwards to the SP through the user's client.
+##### Attribute Consuming Service (ACS)
+The SP may optionally specify one or more Attribute Consuming Services in its metadata. These can be configured in the settings.
+
+If just one ACS is required:
+
+```properties
+# Attribute Consuming Service name when just one ACS should be declared by the SP.
+# Comment out or set to empty if no ACS should be declared, or if multiple ones should (see below). 
+# The service name is mandatory.
+onelogin.saml2.sp.attribute_consuming_service.name = My service
+
+# Attribute Consuming Service description when just one ACS should be declared by the SP.
+# Ignored if the previous property is commented or empty. 
+# The service description is optional.
+onelogin.saml2.sp.attribute_consuming_service.description = My service description
+
+# Language used for Attribute Consuming Service name and description when just one ACS should be declared by the SP.
+# Ignored if the name property is commented or empty. 
+# The language is optional and default to "en" (English).
+onelogin.saml2.sp.attribute_consuming_service.lang = en
+
+# Requested attributes to be included in the Attribute Consuming Service when just one ACS should be declared by the SP.
+# At least one requested attribute must be specified, otherwise schema validation will fail.
+# Attribute properties are indexed properties, starting from 0. The index is used only to enumerate and sort attributes, but it's required.
+# The following properties allow to define each requested attribute:
+# - name: mandatory
+# - name_format: optional; if omitted, defaults to urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified
+# - friendly_name: optional; if omitted, it won't appear in SP metadata
+# - required: optional; if omitted or empty, defaults to false
+# - value[x]: an attribute value; the [x] is only used only to enumerate and sort values, but it's required
+# Please note that only simple values are currently supported and treated internally as strings. Hence no structured values
+# and no ability to specify an xsi:type attribute. 
+# Attribute values are optional and most often they are simply omitted.
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].name = Email
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].name_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].friendly_name = E-mail address
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].required = true
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[0] = foo@example.org
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[1] = bar@example.org
 ```
+
+If multiple ACSs are required, they can be specified in a similar way, but using indexes: these indexes are used to enumerate and
+identify attribute consuming services within the SP metadata and can be subsequently used in the auth process to specify which
+attribute set should be requested to the IdP. The "default" property can also be set to designate the default ACS. Here is an example:
+
+```properties
+onelogin.saml2.sp.attribute_consuming_service[0].name = Just e-mail
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].name = Email
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].name_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].friendly_name = E-mail address
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].required = true
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].value[0] = foo@example.org
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].value[1] = bar@example.org
+onelogin.saml2.sp.attribute_consuming_service[1].name = Anagrafica
+onelogin.saml2.sp.attribute_consuming_service[1].description = Set completo
+onelogin.saml2.sp.attribute_consuming_service[1].lang = it
+onelogin.saml2.sp.attribute_consuming_service[1].default = true
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[0].name = FirstName
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[1].name = LastName
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[1].required = true
+```
+
+Please note that if you specify (multiple) indexed Attribute Consuming Services, the non-indexed properties will be ignored.
+
+As said, to request a specific attribute set when initiating SSO, a selection mechanism is available:
+
+```java
+import static com.onelogin.saml2.authn.AttributeConsumingServiceSelector.*;
+Auth auth = new Auth(request, response);
+// select by index 1
+auth.login(new AuthnRequestParams(false, false, true, byIndex(1));
+// or select by ACS name
+auth.login(new AuthnRequestParams(false, false, true, byServiceName(auth.getSettings(), "Anagrafica"));
+// or see AttributeConsumingServiceSelector interface implementations for more options
+```
+
+If no selector is specified, `AttributeConsumingServiceSelector.useDefault()` will be used, which will simply omit any
+`AttributeConsumingServiceIndex` from the request, hence leaving the IdP choose the default attribute set agreed upon.
+
+Then, the following code handles the SAML response that the IdP forwards to the SP through the user's client:
+
+```java
 Auth auth = new Auth(request, response);
 auth.processResponse();
 if (!auth.isAuthenticated()) {

--- a/core/src/main/java/com/onelogin/saml2/authn/AttributeConsumingServiceSelector.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AttributeConsumingServiceSelector.java
@@ -1,0 +1,75 @@
+package com.onelogin.saml2.authn;
+
+import java.util.List;
+
+import com.onelogin.saml2.model.AttributeConsumingService;
+import com.onelogin.saml2.settings.Saml2Settings;
+
+/**
+ * Interfaced used to select the Attribute Consuming Service to be specified in
+ * an authentication request. An instance of this interface can be passed as an
+ * input parameter in a {@link AuthnRequestParams} to be used when initiating a
+ * login operation.
+ * <p>
+ * A set of predefined implementations are provided: they should cover the most
+ * common cases.
+ */
+@FunctionalInterface
+public interface AttributeConsumingServiceSelector {
+
+	/**
+	 * @return a selector of the default Attribute Consuming Service
+	 */
+	static AttributeConsumingServiceSelector useDefault() {
+		return () -> null;
+	}
+
+	/**
+	 * @param attributeConsumingService
+	 *              the Attribute Consuming Service to select
+	 * @return a selector the chooses the specified Attribute Consuming Service;
+	 *         indeed, its index is used
+	 */
+	static AttributeConsumingServiceSelector use(final AttributeConsumingService attributeConsumingService) {
+		return byIndex(attributeConsumingService.getIndex());
+	}
+
+	/**
+	 * @param index
+	 *              the index of the Attribute Consuming Service to select
+	 * @return a selector that chooses the Attribute Consuming Service with the
+	 *         given index
+	 */
+	static AttributeConsumingServiceSelector byIndex(final int index) {
+		return () -> index;
+	}
+
+	/**
+	 * @param settings
+	 *              the SAML settings, containing the list of the available
+	 *              Attribute Consuming Services (see
+	 *              {@link Saml2Settings#getSpAttributeConsumingServices()})
+	 * @param serviceName
+	 *              the name of the Attribute Consuming Service to select
+	 * @return a selector that chooses the Attribute Consuming Service with the
+	 *         given name; please note that this selector will select the default
+	 *         service if no one is found with the given name
+	 */
+	static AttributeConsumingServiceSelector byServiceName(final Saml2Settings settings, final String serviceName) {
+		return () -> {
+			final List<AttributeConsumingService> services = settings.getSpAttributeConsumingServices();
+			if (services != null)
+				return services.stream().filter(service -> service.getServiceName().equals(serviceName))
+				            .findFirst().map(AttributeConsumingService::getIndex).orElse(null);
+			else
+				return null;
+		};
+	}
+
+	/**
+	 * Returns the index of the selected Attribute Consuming Service.
+	 * 
+	 * @return the service index, or <code>null</code> if the default one should be selected
+	 */
+	Integer getAttributeConsumingServiceIndex();
+}

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -21,7 +21,7 @@ import com.onelogin.saml2.util.Util;
  *
  * A class that implements SAML 2 Authentication Request
  */
-public class AuthnRequest {
+public class AuthnRequest extends AuthnRequestParams {
 	/**
      * Private property to construct a logger for this class.
      */
@@ -43,26 +43,6 @@ public class AuthnRequest {
 	private final Saml2Settings settings;
 
 	/**
-	 * When true the AuthNRequest will set the ForceAuthn='true'
-	 */
-	private final boolean forceAuthn;
-
-	/**
-	 * When true the AuthNRequest will set the IsPassive='true'
-	 */
-	private final boolean isPassive;
-
-	/**
-	 * When true the AuthNReuqest will set a nameIdPolicy
-	 */
-	private final boolean setNameIdPolicy;
-
-	/**
-	 * Indicates to the IdP the subject that should be authenticated
-	 */
-	private final String nameIdValueReq;
-	
-	/**
 	 * Time stamp that indicates when the AuthNRequest was created
 	 */
 	private final Calendar issueInstant;
@@ -81,44 +61,62 @@ public class AuthnRequest {
 	 * Constructs the AuthnRequest object.
 	 *
 	 * @param settings
-	 *            OneLogin_Saml2_Settings
+	 *              OneLogin_Saml2_Settings
 	 * @param forceAuthn
-	 *            When true the AuthNReuqest will set the ForceAuthn='true'
+	 *              When true the AuthNReuqest will set the ForceAuthn='true'
 	 * @param isPassive
-	 *            When true the AuthNReuqest will set the IsPassive='true'
+	 *              When true the AuthNReuqest will set the IsPassive='true'
 	 * @param setNameIdPolicy
-	 *            When true the AuthNReuqest will set a nameIdPolicy
+	 *              When true the AuthNReuqest will set a nameIdPolicy
 	 * @param nameIdValueReq
-	 *            Indicates to the IdP the subject that should be authenticated
+	 *              Indicates to the IdP the subject that should be authenticated
+	 * @deprecated use {@link #AuthnRequest(Saml2Settings, AuthnRequestParams)} with
+	 *             {@link AuthnRequestParams#AuthnRequestParams(boolean, boolean, boolean, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public AuthnRequest(Saml2Settings settings, boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy, String nameIdValueReq) {
-		this.id = Util.generateUniqueID(settings.getUniqueIDPrefix());
-		issueInstant = Calendar.getInstance();
-		this.isPassive = isPassive;
-		this.settings = settings;
-		this.forceAuthn = forceAuthn;
-		this.setNameIdPolicy = setNameIdPolicy;
-		this.nameIdValueReq = nameIdValueReq;
-
-		StrSubstitutor substitutor = generateSubstitutor(settings);
-		authnRequestString = substitutor.replace(getAuthnRequestTemplate());
-		LOGGER.debug("AuthNRequest --> " + authnRequestString);
+		this(settings, new AuthnRequestParams(forceAuthn, isPassive, setNameIdPolicy, nameIdValueReq));
+	}
+	
+	/**
+	 * Constructs the AuthnRequest object.
+	 *
+	 * @param settings
+	 *              OneLogin_Saml2_Settings
+	 * @param forceAuthn
+	 *              When true the AuthNReuqest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNReuqest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNReuqest will set a nameIdPolicy
+	 * @deprecated use {@link #AuthnRequest(Saml2Settings, AuthnRequestParams)} with
+	 *             {@link AuthnRequestParams#AuthnRequestParams(boolean, boolean, boolean)}
+	 *             instead
+	 */
+	@Deprecated
+	public AuthnRequest(Saml2Settings settings, boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy) {
+		this(settings, forceAuthn, isPassive, setNameIdPolicy, null);
 	}
 
 	/**
 	 * Constructs the AuthnRequest object.
 	 *
 	 * @param settings
-	 *            OneLogin_Saml2_Settings
-	 * @param forceAuthn
-	 *            When true the AuthNReuqest will set the ForceAuthn='true'
-	 * @param isPassive
-	 *            When true the AuthNReuqest will set the IsPassive='true'
-	 * @param setNameIdPolicy
-	 *            When true the AuthNReuqest will set a nameIdPolicy
+	 *              OneLogin_Saml2_Settings
+	 * @param params
+	 *              a set of authentication request input parameters that shape the
+	 *              request to create
 	 */
-	public AuthnRequest(Saml2Settings settings, boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy) {
-		this(settings, forceAuthn, isPassive, setNameIdPolicy, null);
+	public AuthnRequest(Saml2Settings settings, AuthnRequestParams params) {
+		super(params);
+		this.id = Util.generateUniqueID(settings.getUniqueIDPrefix());
+		issueInstant = Calendar.getInstance();
+		this.settings = settings;
+
+		StrSubstitutor substitutor = generateSubstitutor(settings);
+		authnRequestString = substitutor.replace(getAuthnRequestTemplate());
+		LOGGER.debug("AuthNRequest --> " + authnRequestString);
 	}
 
 	/**
@@ -171,12 +169,12 @@ public class AuthnRequest {
 		Map<String, String> valueMap = new HashMap<String, String>();
 
 		String forceAuthnStr = "";
-		if (forceAuthn) {
+		if (isForceAuthn()) {
 			forceAuthnStr = " ForceAuthn=\"true\"";
 		}
 
 		String isPassiveStr = "";
-		if (isPassive) {
+		if (isPassive()) {
 			isPassiveStr = " IsPassive=\"true\"";
 		}
 
@@ -191,6 +189,7 @@ public class AuthnRequest {
 		valueMap.put("destinationStr", destinationStr);
 
 		String subjectStr = "";
+		String nameIdValueReq = getNameIdValueReq();
 		if (nameIdValueReq != null && !nameIdValueReq.isEmpty()) {
 			String nameIDFormat = settings.getSpNameIDFormat();
 			subjectStr = "<saml:Subject>";
@@ -201,7 +200,7 @@ public class AuthnRequest {
         valueMap.put("subjectStr", subjectStr);
 
 		String nameIDPolicyStr = "";
-		if (setNameIdPolicy) {
+		if (isSetNameIdPolicy()) {
 			String nameIDPolicyFormat = settings.getSpNameIDFormat();
 			if (settings.getWantNameIdEncrypted()) {
 				nameIDPolicyFormat = Constants.NAMEID_ENCRYPTED;
@@ -239,6 +238,12 @@ public class AuthnRequest {
 		}
 
 		valueMap.put("requestedAuthnContextStr", requestedAuthnContextStr);
+		
+		String attributeConsumingServiceIndexStr = "";
+		final Integer acsIndex = getAttributeConsumingServiceSelector().getAttributeConsumingServiceIndex();
+		if (acsIndex != null)
+			attributeConsumingServiceIndexStr = " AttributeConsumingServiceIndex=\"" + acsIndex + "\"";
+		valueMap.put("attributeConsumingServiceIndexStr", attributeConsumingServiceIndexStr);
 
 		return new StrSubstitutor(valueMap);
 	}
@@ -248,7 +253,7 @@ public class AuthnRequest {
 	 */
 	private static StringBuilder getAuthnRequestTemplate() {
 		StringBuilder template = new StringBuilder();
-		template.append("<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"${id}\" Version=\"2.0\" IssueInstant=\"${issueInstant}\"${providerStr}${forceAuthnStr}${isPassiveStr}${destinationStr} ProtocolBinding=\"${protocolBinding}\" AssertionConsumerServiceURL=\"${assertionConsumerServiceURL}\">");
+		template.append("<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"${id}\" Version=\"2.0\" IssueInstant=\"${issueInstant}\"${providerStr}${forceAuthnStr}${isPassiveStr}${destinationStr} ProtocolBinding=\"${protocolBinding}\" AssertionConsumerServiceURL=\"${assertionConsumerServiceURL}${attributeConsumingServiceIndexStr}\">");
 		template.append("<saml:Issuer>${spEntityid}</saml:Issuer>");
 		template.append("${subjectStr}${nameIDPolicyStr}${requestedAuthnContextStr}</samlp:AuthnRequest>");
 		return template;

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequestParams.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequestParams.java
@@ -1,0 +1,169 @@
+package com.onelogin.saml2.authn;
+
+/**
+ * Input parameters for a SAML 2 authentication request.
+ */
+public class AuthnRequestParams {
+
+	/**
+	 * When true the AuthNRequest will set the ForceAuthn='true'
+	 */
+	private final boolean forceAuthn;
+	/**
+	 * When true the AuthNRequest will set the IsPassive='true'
+	 */
+	private final boolean isPassive;
+	/**
+	 * When true the AuthNReuqest will set a nameIdPolicy
+	 */
+	private final boolean setNameIdPolicy;
+	/**
+	 * Indicates to the IdP the subject that should be authenticated
+	 */
+	private final String nameIdValueReq;
+
+	/*
+	 * / Selector to use to specify the Attribute Consuming Service index
+	 */
+	private AttributeConsumingServiceSelector attributeConsumingServiceSelector;
+
+	/**
+	 * Create a set of authentication request input parameters. The
+	 * {@link AttributeConsumingServiceSelector#useDefault()} selector is used to
+	 * select the Attribute Consuming Service.
+	 *
+	 * @param forceAuthn
+	 *              whether the <code>ForceAuthn</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param isPassive
+	 *              whether the <code>isPassive</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param setNameIdPolicy
+	 *              whether a <code>NameIDPolicy</code> should be set
+	 */
+	public AuthnRequestParams(boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy) {
+		this(forceAuthn, isPassive, setNameIdPolicy, null, null);
+	}
+
+	/**
+	 * Create a set of authentication request input parameters. The
+	 * {@link AttributeConsumingServiceSelector#useDefault()} selector is used to
+	 * select the Attribute Consuming Service.
+	 *
+	 * @param forceAuthn
+	 *              whether the <code>ForceAuthn</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param isPassive
+	 *              whether the <code>isPassive</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param setNameIdPolicy
+	 *              whether a <code>NameIDPolicy</code> should be set
+	 * @param nameIdValueReq
+	 *              the subject that should be authenticated
+	 */
+	public AuthnRequestParams(boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy, String nameIdValueReq) {
+		this(forceAuthn, isPassive, setNameIdPolicy, nameIdValueReq, null);
+	}
+
+	/**
+	 * Create a set of authentication request input parameters.
+	 *
+	 * @param forceAuthn
+	 *              whether the <code>ForceAuthn</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param isPassive
+	 *              whether the <code>isPassive</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param setNameIdPolicy
+	 *              whether a <code>NameIDPolicy</code> should be set
+	 * @param attributeConsumingServiceSelector
+	 *              the selector to use to specify the Attribute Consuming Service
+	 *              index; if <code>null</code>,
+	 *              {@link AttributeConsumingServiceSelector#useDefault()} is used
+	 */
+	public AuthnRequestParams(boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy,
+	            AttributeConsumingServiceSelector attributeConsumingServiceSelector) {
+		this(forceAuthn, isPassive, setNameIdPolicy, null, attributeConsumingServiceSelector);
+	}
+
+	/**
+	 * Create a set of authentication request input parameters.
+	 *
+	 * @param forceAuthn
+	 *              whether the <code>ForceAuthn</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param isPassive
+	 *              whether the <code>isPassive</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param setNameIdPolicy
+	 *              whether a <code>NameIDPolicy</code> should be set
+	 * @param nameIdValueReq
+	 *              the subject that should be authenticated
+	 * @param attributeConsumingServiceSelector
+	 *              the selector to use to specify the Attribute Consuming Service
+	 *              index; if <code>null</code>,
+	 *              {@link AttributeConsumingServiceSelector#useDefault()} is used
+	 */
+	public AuthnRequestParams(boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy, String nameIdValueReq,
+	            AttributeConsumingServiceSelector attributeConsumingServiceSelector) {
+		this.forceAuthn = forceAuthn;
+		this.isPassive = isPassive;
+		this.setNameIdPolicy = setNameIdPolicy;
+		this.nameIdValueReq = nameIdValueReq;
+		this.attributeConsumingServiceSelector = attributeConsumingServiceSelector != null
+		            ? attributeConsumingServiceSelector
+		            : AttributeConsumingServiceSelector.useDefault();
+	}
+
+	/**
+	 * Create a set of authentication request input parameters, by copying them from
+	 * another set.
+	 *
+	 * @param source
+	 *              the source set of authentication request input parameters
+	 */
+	protected AuthnRequestParams(AuthnRequestParams source) {
+		this.forceAuthn = source.isForceAuthn();
+		this.isPassive = source.isPassive();
+		this.setNameIdPolicy = source.isSetNameIdPolicy();
+		this.nameIdValueReq = source.getNameIdValueReq();
+		this.attributeConsumingServiceSelector = source.getAttributeConsumingServiceSelector();
+	}
+
+	/**
+	 * @return whether the <code>ForceAuthn</code> attribute should be set to
+	 *         <code>true</code>
+	 */
+	protected boolean isForceAuthn() {
+		return forceAuthn;
+	}
+
+	/**
+	 * @return whether the <code>isPassive</code> attribute should be set to
+	 *         <code>true</code>
+	 */
+	protected boolean isPassive() {
+		return isPassive;
+	}
+
+	/**
+	 * @return whether a <code>NameIDPolicy</code> should be set
+	 */
+	protected boolean isSetNameIdPolicy() {
+		return setNameIdPolicy;
+	}
+
+	/**
+	 * @return the subject that should be authenticated
+	 */
+	protected String getNameIdValueReq() {
+		return nameIdValueReq;
+	}
+
+	/**
+	 * @return the selector to use to specify the Attribute Consuming Service index
+	 */
+	public AttributeConsumingServiceSelector getAttributeConsumingServiceSelector() {
+		return attributeConsumingServiceSelector;
+	}
+}

--- a/core/src/main/java/com/onelogin/saml2/model/AttributeConsumingService.java
+++ b/core/src/main/java/com/onelogin/saml2/model/AttributeConsumingService.java
@@ -11,6 +11,14 @@ import com.onelogin.saml2.model.RequestedAttribute;
  */
 public class AttributeConsumingService {
 	/**
+	 * Service Index
+	 */
+	private final int index;
+	/**
+	 * Whether this service is the default one
+	 */
+	private final Boolean isDefault;
+	/**
      * Service Name
      */
 	private final String serviceName;
@@ -21,12 +29,60 @@ public class AttributeConsumingService {
 	private final String serviceDescription;
 
 	/**
+	 * Language used for service name and description
+	 */
+	private final String lang;
+
+	/**
      * Requested Attributes
      */
 	private final List<RequestedAttribute> requestedAttributes;
 
 	/**
 	 * Constructor
+	 * 
+	 * @param index
+	 *              int. Service index
+	 * @param isDefault
+	 *              boolean. Whether it's the default attribute consuming service
+	 * @param serviceName
+	 *              String. Service Name
+	 * @param serviceDescription
+	 *              String. Service Description
+	 * @param lang
+	 *              String. Language in which service name and description are
+	 *              written; defaults to <code>en</code> if <code>null</code> is specified
+	 */
+	public AttributeConsumingService(int index, Boolean isDefault, String serviceName, String serviceDescription, String lang) {
+		this.index = index;
+		this.isDefault = isDefault;
+		this.serviceName = serviceName != null? serviceName : "";
+		this.serviceDescription = serviceDescription != null? serviceDescription : "";
+		this.lang = lang != null? lang: "en";
+		this.requestedAttributes = new ArrayList<RequestedAttribute>(); 
+	}
+
+	/**
+	 * Constructor. Service name and description are assumed to be in English.
+	 * 
+	 * @param index
+	 *              int. Service index
+	 * @param isDefault
+	 *              boolean. Whether it's the default attribute consuming service
+	 * @param serviceName
+	 *              String. Service Name
+	 * @param serviceDescription
+	 *              String. Service Description
+	 */
+	public AttributeConsumingService(int index, Boolean isDefault, String serviceName, String serviceDescription) {
+		this(index, isDefault, serviceName, serviceDescription, null);
+	}
+
+	/**
+	 * Constructor for a non-default attribute consuming service with index <code>1</code>
+	 * and service name and descriptions in English.
+	 * Mainly kept for backward compatibility, this constructor can be used when an only
+	 * attribute consuming service is required.
 	 *
 	 * @param serviceName
 	 *              String. Service Name
@@ -34,9 +90,7 @@ public class AttributeConsumingService {
 	 *              String. Service Description
 	 */
 	public AttributeConsumingService(String serviceName, String serviceDescription) {
-		this.serviceName = serviceName != null? serviceName : "";
-		this.serviceDescription = serviceDescription != null? serviceDescription : "";
-		this.requestedAttributes = new ArrayList<RequestedAttribute>(); 
+		this(1, null, serviceName, serviceDescription, null);
 	}
 
 	/**
@@ -45,6 +99,20 @@ public class AttributeConsumingService {
 	 */
 	public final void addRequestedAttribute(RequestedAttribute attr) {
 		this.requestedAttributes.add(attr);
+	}
+	
+	/**
+	 * @return int the service index
+	 */
+	public final int getIndex() {
+		  return index;
+	}
+	
+	/**
+	 * @return boolean whether this is the default attribute consuming service
+	 */
+	public final Boolean isDefault() {
+		  return isDefault;
 	}
 	
 	/**
@@ -61,6 +129,13 @@ public class AttributeConsumingService {
 		return serviceDescription;
 	}
 
+	/**
+	 * @return string the language in which service name and description are written
+	 */
+	public String getLang() {
+		return lang;
+	}
+	
 	/**
 	 * @return List the requested attributes
 	 */

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -43,8 +43,11 @@ public class Metadata {
 	private static final int SECONDS_CACHED = 604800; // 1 week
 
 	/**
-     * AttributeConsumingService
-     */
+	 * AttributeConsumingService
+	 * 
+	 * @deprecated Attribute Consuming Services should be specified in settings
+	 */
+	@Deprecated
 	private AttributeConsumingService attributeConsumingService = null;
 
 	/**
@@ -70,7 +73,12 @@ public class Metadata {
 	 * @param cacheDuration             Duration of the cache in seconds
 	 * @param attributeConsumingService AttributeConsumingService of service provider
 	 * @throws CertificateEncodingException
+	 * @deprecated Attribute Consuming Services should be specified in settings; if
+	 *             a non-<code>null</code> service is specified here, it will be
+	 *             used in place of the ones specified in settings to generate
+	 *             metadata
 	 */
+	@Deprecated
 	public Metadata(Saml2Settings settings, Calendar validUntilTime, Integer cacheDuration, AttributeConsumingService attributeConsumingService) throws CertificateEncodingException {
 		this.validUntilTime = validUntilTime;
 		this.attributeConsumingService = attributeConsumingService;
@@ -149,7 +157,12 @@ public class Metadata {
 		valueMap.put("spAssertionConsumerServiceUrl", settings.getSpAssertionConsumerServiceUrl().toString());
 		valueMap.put("sls", toSLSXml(settings.getSpSingleLogoutServiceUrl(), settings.getSpSingleLogoutServiceBinding()));
 
-		valueMap.put("strAttributeConsumingService", getAttributeConsumingServiceXml());
+		// if an ACS was specified at construction time, use it in place of the ones specified in settings
+		// this is for backward compatibility
+		valueMap.put("strAttributeConsumingService",
+		            toAttributeConsumingServicesXml(attributeConsumingService != null 
+		            	? Arrays.asList(attributeConsumingService)
+		            	: settings.getSpAttributeConsumingServices()));
 
 		valueMap.put("strKeyDescriptor", toX509KeyDescriptorsXML(settings.getSPcert(), settings.getSPcertNew(), wantsEncrypted));
 
@@ -186,63 +199,86 @@ public class Metadata {
 
 	/**
 	 * Generates the AttributeConsumingService section of the metadata's template
+	 * 
+	 * @param attributeConsumingServices
+	 *              a list containing the Attribute Consuming Services to generate
+	 *              the metadata for
 	 *
 	 * @return the AttributeConsumingService section of the metadata's template
 	 */
-	private String getAttributeConsumingServiceXml() {
+	private String toAttributeConsumingServicesXml(List<AttributeConsumingService> attributeConsumingServices) {
+		final StringBuilder acssXml = new StringBuilder();
+		if (attributeConsumingServices != null)
+			attributeConsumingServices.stream().forEach(service -> acssXml.append(toAttributeConsumingServiceXml(service)));
+		return acssXml.toString();
+	}
+	
+	/**
+	 * Generates a single Attribute Consuming Service metadata fragment
+	 * 
+	 * @param service
+	 *              the Attribute Consuming Service for which the XML fragment
+	 *              should be generated
+	 * @return the generated XML fragment
+	 */
+	private String toAttributeConsumingServiceXml(AttributeConsumingService service) {
+		int index = service.getIndex();
+		Boolean isDefault = service.isDefault();
+		String serviceName = service.getServiceName();
+		String serviceDescription = service.getServiceDescription();
+		String lang = service.getLang();
+		List<RequestedAttribute> requestedAttributes = service.getRequestedAttributes();
 		StringBuilder attributeConsumingServiceXML = new StringBuilder();
-		if (attributeConsumingService != null) {
-			String serviceName = attributeConsumingService.getServiceName();
-			String serviceDescription = attributeConsumingService.getServiceDescription();
-			List<RequestedAttribute> requestedAttributes = attributeConsumingService.getRequestedAttributes();
+		attributeConsumingServiceXML.append("<md:AttributeConsumingService index=\"").append(index).append("\"");
+		if(isDefault != null)
+			attributeConsumingServiceXML.append(" isDefault=\"").append(isDefault).append("\"");
+		attributeConsumingServiceXML.append(">");
+		if (serviceName != null && !serviceName.isEmpty()) {
+			attributeConsumingServiceXML.append("<md:ServiceName xml:lang=\"").append(lang).append("\">")
+			            .append(serviceName).append("</md:ServiceName>");
+		}
+		if (serviceDescription != null && !serviceDescription.isEmpty()) {
+			attributeConsumingServiceXML.append("<md:ServiceDescription xml:lang=\"").append(lang).append("\">")
+			            .append(serviceDescription).append("</md:ServiceDescription>");
+		}
+		if (requestedAttributes != null && !requestedAttributes.isEmpty()) {
+			for (RequestedAttribute requestedAttribute : requestedAttributes) {
+				String name = requestedAttribute.getName();
+				String friendlyName = requestedAttribute.getFriendlyName();
+				String nameFormat = requestedAttribute.getNameFormat();
+				Boolean isRequired = requestedAttribute.isRequired();
+				List<String> attrValues = requestedAttribute.getAttributeValues();
 
-			attributeConsumingServiceXML.append("<md:AttributeConsumingService index=\"1\">");
-			if (serviceName != null && !serviceName.isEmpty()) {
-				attributeConsumingServiceXML.append("<md:ServiceName xml:lang=\"en\">" + serviceName + "</md:ServiceName>");
-			}
-			if (serviceDescription != null && !serviceDescription.isEmpty()) {
-				attributeConsumingServiceXML.append("<md:ServiceDescription xml:lang=\"en\">" + serviceDescription + "</md:ServiceDescription>");
-			}
-			if (requestedAttributes != null && !requestedAttributes.isEmpty()) {
-				for (RequestedAttribute requestedAttribute : requestedAttributes) {
-					String name = requestedAttribute.getName();
-					String friendlyName = requestedAttribute.getFriendlyName();
-					String nameFormat = requestedAttribute.getNameFormat();
-					Boolean isRequired = requestedAttribute.isRequired();
-					List<String> attrValues = requestedAttribute.getAttributeValues();
+				StringBuilder contentStr = new StringBuilder("<md:RequestedAttribute");
 
-					String contentStr = "<md:RequestedAttribute";
+				if (name != null && !name.isEmpty()) {
+					contentStr.append(" Name=\"").append(name).append("\"");
+				}
 
-					if (name != null && !name.isEmpty()) {
-						contentStr += " Name=\"" + name + "\"";
+				if (nameFormat != null && !nameFormat.isEmpty()) {
+					contentStr.append(" NameFormat=\"").append(nameFormat).append("\"");
+				}
+
+				if (friendlyName != null && !friendlyName.isEmpty()) {
+					contentStr.append(" FriendlyName=\"").append(friendlyName).append("\"");
+				}
+
+				if (isRequired != null) {
+					contentStr.append(" isRequired=\"").append(isRequired.toString()).append("\"");
+				}
+
+				if (attrValues != null && !attrValues.isEmpty()) {
+					contentStr.append(">");
+					for (String attrValue : attrValues) {
+						contentStr.append("<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">").append(attrValue).append("</saml:AttributeValue>");
 					}
-
-					if (nameFormat != null && !nameFormat.isEmpty()) {
-						contentStr += " NameFormat=\"" + nameFormat + "\"";
-					}
-
-					if (friendlyName != null && !friendlyName.isEmpty()) {
-						contentStr += " FriendlyName=\"" + friendlyName + "\"";
-					}
-
-					if (isRequired != null) {
-						contentStr += " isRequired=\"" + isRequired.toString() + "\"";
-					}
-
-					if (attrValues != null && !attrValues.isEmpty()) {
-						contentStr += ">";
-						for (String attrValue : attrValues) {
-							contentStr += "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" + attrValue + "</saml:AttributeValue>";
-						}
-						attributeConsumingServiceXML.append(contentStr + "</md:RequestedAttribute>");
-					} else {
-						attributeConsumingServiceXML.append(contentStr + " />");
-					}
+					attributeConsumingServiceXML.append(contentStr).append("</md:RequestedAttribute>");
+				} else {
+					attributeConsumingServiceXML.append(contentStr).append(" />");
 				}
 			}
-			attributeConsumingServiceXML.append("</md:AttributeConsumingService>");
 		}
-
+		attributeConsumingServiceXML.append("</md:AttributeConsumingService>");
 		return attributeConsumingServiceXML.toString();
 	}
 

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -13,6 +13,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import com.onelogin.saml2.model.AttributeConsumingService;
 import com.onelogin.saml2.model.Contact;
 import com.onelogin.saml2.model.Organization;
 import com.onelogin.saml2.util.Constants;
@@ -45,6 +47,7 @@ public class Saml2Settings {
 	private X509Certificate spX509certNew = null;
 	private PrivateKey spPrivateKey = null;
 	private HSM hsm = null;
+	private List<AttributeConsumingService> spAttributeConsumingServices = new ArrayList<>();
 
 	// IdP
 	private String idpEntityId = "";
@@ -117,6 +120,13 @@ public class Saml2Settings {
 		return spAssertionConsumerServiceBinding;
 	}
 
+	/**
+	 * @return the SP Attribute Consuming Services 
+	 */
+	public final List<AttributeConsumingService> getSpAttributeConsumingServices() {
+		  return spAttributeConsumingServices;
+	}
+	
 	/**
 	 * @return the spSingleLogoutServiceUrl setting value
 	 */
@@ -844,6 +854,17 @@ public class Saml2Settings {
 		return compressResponse;
 	}
 
+	/**
+	 * Set the Attribute Consuming Services to be declared in the Service Provider
+	 * metadata
+	 * 
+	 * @param spAttributeConsumingServices
+	 *              the Attribute Consuming Services to set
+	 */
+	protected final void setSpAttributeConsumingServices(List<AttributeConsumingService> spAttributeConsumingServices) {
+		this.spAttributeConsumingServices = spAttributeConsumingServices;
+	}
+	
 	/**
 	 * Set contacts info that will be listed on the Service Provider metadata
 	 * 

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -11,7 +11,10 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.onelogin.saml2.authn.AttributeConsumingServiceSelector;
 import com.onelogin.saml2.authn.AuthnRequest;
+import com.onelogin.saml2.authn.AuthnRequestParams;
+import com.onelogin.saml2.model.AttributeConsumingService;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Util;
@@ -133,13 +136,13 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("ForceAuthn=\"true\"")));
 
-		authnRequest = new AuthnRequest(settings, false, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("ForceAuthn=\"true\"")));		
 
-		authnRequest = new AuthnRequest(settings, true, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(true, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -164,13 +167,13 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("IsPassive=\"true\"")));
 
-		authnRequest = new AuthnRequest(settings, false, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("IsPassive=\"true\"")));		
 
-		authnRequest = new AuthnRequest(settings, false, true, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, true, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -196,13 +199,13 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:NameIDPolicy"));
 		assertThat(authnRequestStr, containsString("Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\""));
 
-		authnRequest = new AuthnRequest(settings, false, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("<samlp:NameIDPolicy")));		
 
-		authnRequest = new AuthnRequest(settings, false, false, true);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, true));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -290,7 +293,7 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("<saml:Subject")));
 
-		authnRequest = new AuthnRequest(settings, false, false, false, "testuser@example.com");
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, "testuser@example.com"));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -299,13 +302,64 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">"));
 
 		settings = new SettingsBuilder().fromFile("config/config.emailaddressformat.properties").build();
-		authnRequest = new AuthnRequest(settings, false, false, false, "testuser@example.com");
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, "testuser@example.com"));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, containsString("<saml:Subject"));
 		assertThat(authnRequestStr, containsString("Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">testuser@example.com</saml:NameID>"));
 		assertThat(authnRequestStr, containsString("<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">"));
+	}
+
+	/**
+	 * Tests the AuthnRequest Constructor
+	 * The creation of a deflated SAML Request with the index of the desired Attribute Consuming Service
+	 *
+	 * @throws Exception
+	 *
+	 * @see com.onelogin.saml2.authn.AuthnRequest
+	 */
+	@Test
+	public void testAttributeConsumingServiceSelector() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min_multi_attribute_consuming_services.properties").build();
+
+		AuthnRequest authnRequest = new AuthnRequest(settings);
+		String authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
+		String authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, not(containsString("AttributeConsumingServiceIndex=\"")));
+
+		// use default
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, 
+				AttributeConsumingServiceSelector.useDefault()));
+		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
+		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, not(containsString("AttributeConsumingServiceIndex=\"")));		
+
+		// by index
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, 
+				AttributeConsumingServiceSelector.byIndex(0)));
+		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
+		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, containsString("AttributeConsumingServiceIndex=\"0\""));
+		
+		// by service name
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, 
+				AttributeConsumingServiceSelector.byServiceName(settings, "Anagrafica")));
+		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
+		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, containsString("AttributeConsumingServiceIndex=\"1\""));
+		
+		// use service
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, 
+				AttributeConsumingServiceSelector.use(new AttributeConsumingService(2, false, "Test", null, null))));
+		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
+		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, containsString("AttributeConsumingServiceIndex=\"2\""));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
@@ -296,15 +296,59 @@ public class MetadataTest {
 	}
 
 	/**
-	 * Tests the getAttributeConsumingServiceXml method of Metadata
+	 * Tests the toAttributeConsumingServicesXml method of Metadata when an Attribute Consuming Service
+	 * is specified at construction time
 	 *
 	 * @throws IOException
 	 * @throws CertificateEncodingException
 	 * @throws Error
-	 * @see com.onelogin.saml2.settings.Metadata#getAttributeConsumingServiceXml
+	 * @see com.onelogin.saml2.settings.Metadata#toAttributeConsumingServicesXml
 	 */
 	@Test
-	public void testGetAttributeConsumingServiceXml() throws IOException, CertificateEncodingException, Error {
+	public void testToAttributeConsumingServicesXmlLegacy() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = getSettingFromAllProperties();
+
+		AttributeConsumingService attributeConsumingService = new AttributeConsumingService(0, true, "Test Service", "Test Service Desc", "en");
+		RequestedAttribute requestedAttribute = new RequestedAttribute("Email", "Email", true, "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", null);
+		RequestedAttribute requestedAttribute2 = new RequestedAttribute("FirstName", null, true, "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", null);
+		RequestedAttribute requestedAttribute3 = new RequestedAttribute("LastName", null, true, "urn:oasis:names:tc:SAML:2.0:attrname-format:uri", null);
+
+		attributeConsumingService.addRequestedAttribute(requestedAttribute);
+		attributeConsumingService.addRequestedAttribute(requestedAttribute2);
+		attributeConsumingService.addRequestedAttribute(requestedAttribute3);
+
+		Metadata metadataObj = new Metadata(settings, null, null, attributeConsumingService);
+		String metadataStr = metadataObj.getMetadataString();
+
+		String headerStr = "<md:AttributeConsumingService index=\"0\" isDefault=\"true\">";
+		String sNameStr = "<md:ServiceName xml:lang=\"en\">Test Service</md:ServiceName>";
+		String sDescStr = "<md:ServiceDescription xml:lang=\"en\">Test Service Desc</md:ServiceDescription>";
+		String reqAttr1Str = "<md:RequestedAttribute Name=\"Email\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" FriendlyName=\"Email\" isRequired=\"true\" />";
+		String reqAttr2Str = "<md:RequestedAttribute Name=\"FirstName\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" isRequired=\"true\" />";
+		String reqAttr3Str = "<md:RequestedAttribute Name=\"LastName\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" isRequired=\"true\" />";
+		String footerStr = "</md:AttributeConsumingService>";
+
+		assertThat(metadataStr, containsString(headerStr));
+		assertThat(metadataStr, containsString(sNameStr));
+		assertThat(metadataStr, containsString(sDescStr));
+		assertThat(metadataStr, containsString(reqAttr1Str));
+		assertThat(metadataStr, containsString(reqAttr2Str));
+		assertThat(metadataStr, containsString(reqAttr3Str));
+		assertThat(metadataStr, containsString(footerStr));
+	}
+
+	/**
+	 * Tests the toAttributeConsumingServicesXml method of Metadata when an Attribute Consuming Service
+	 * is specified at construction time
+	 * Case: Single non-default AttributeConsumingService with no explicit index 
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 * @see com.onelogin.saml2.settings.Metadata#toAttributeConsumingServicesXml
+	 */
+	@Test
+	public void testToAttributeConsumingServiceXmlNoIndexLegacy() throws IOException, CertificateEncodingException, Error {
 		Saml2Settings settings = getSettingFromAllProperties();
 
 		AttributeConsumingService attributeConsumingService = new AttributeConsumingService("Test Service", "Test Service Desc");
@@ -337,19 +381,20 @@ public class MetadataTest {
 	}
 
 	/**
-	 * Tests the getAttributeConsumingServiceXml method of Metadata
+	 * Tests the toAttributeConsumingServicesXml method of Metadata when an Attribute Consuming Service
+	 * is specified at construction time
 	 * Case: AttributeConsumingService Multiple AttributeValue
 	 *
 	 * @throws IOException
 	 * @throws CertificateEncodingException
 	 * @throws Error
-	 * @see com.onelogin.saml2.settings.Metadata#getAttributeConsumingServiceXml
+	 * @see com.onelogin.saml2.settings.Metadata#toAttributeConsumingServicesXml
 	 */
 	@Test
-	public void testGetAttributeConsumingServiceXmlWithMultipleAttributeValue() throws IOException, CertificateEncodingException, Error {
+	public void testToAttributeConsumingServiceXmlWithMultipleAttributeValueLegacy() throws IOException, CertificateEncodingException, Error {
 		Saml2Settings settings = getSettingFromAllProperties();
 
-		AttributeConsumingService attributeConsumingService = new AttributeConsumingService("Test Service", "Test Service Desc");
+		AttributeConsumingService attributeConsumingService = new AttributeConsumingService(0, true, "Test Service", "Test Service Desc", "en");
 		List<String> attrValues = new ArrayList<String>();
 		attrValues.add("userType");
 		attrValues.add("admin");
@@ -362,7 +407,7 @@ public class MetadataTest {
 		Metadata metadataObj = new Metadata(settings, null, null, attributeConsumingService);
 		String metadataStr = metadataObj.getMetadataString();
 
-		String headerStr = "<md:AttributeConsumingService index=\"1\">";
+		String headerStr = "<md:AttributeConsumingService index=\"0\" isDefault=\"true\">";
 		String sNameStr = "<md:ServiceName xml:lang=\"en\">Test Service</md:ServiceName>";
 		String sDescStr = "<md:ServiceDescription xml:lang=\"en\">Test Service Desc</md:ServiceDescription>";
 		String reqAttr1Str = "<md:RequestedAttribute Name=\"userType\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:basic\" isRequired=\"false\">";
@@ -379,6 +424,101 @@ public class MetadataTest {
 		assertThat(metadataStr, containsString(reqAttr1Attr2Str));
 		assertThat(metadataStr, containsString(reqAttr2Str));
 		assertThat(metadataStr, containsString(footerStr));
+	}
+
+	/**
+	 * Tests the toAttributeConsumingServicesXml method of Metadata
+	 * Case: single Attribute Consuming Service specified in settings
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 * @see com.onelogin.saml2.settings.Metadata#toAttributeConsumingServicesXml
+	 */
+	@Test
+	public void testToAttributeConsumingServiceXmlSingleACS() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = getSettingFromAllProperties();
+
+		Metadata metadataObj = new Metadata(settings, null, null);
+		String metadataStr = metadataObj.getMetadataString();
+
+		String headerStr = "<md:AttributeConsumingService index=\"1\">";
+		String sNameStr = "<md:ServiceName xml:lang=\"en\">My service</md:ServiceName>";
+		String sDescStr = "<md:ServiceDescription xml:lang=\"en\">My service description</md:ServiceDescription>";
+		String reqAttr1Str = "<md:RequestedAttribute Name=\"Email\" NameFormat=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\" FriendlyName=\"E-mail address\" isRequired=\"true\">";
+		String reqAttr1Atr1Str = "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">foo@example.org</saml:AttributeValue>";
+		String reqAttr1Attr2Str = "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">bar@example.org</saml:AttributeValue>";
+		String reqAttr2Str = "<md:RequestedAttribute Name=\"FirstName\" />";
+		String footerStr = "</md:AttributeConsumingService>";
+
+		assertThat(metadataStr, containsString(headerStr));
+		assertThat(metadataStr, containsString(sNameStr));
+		assertThat(metadataStr, containsString(sDescStr));
+		assertThat(metadataStr, containsString(reqAttr1Str));
+		assertThat(metadataStr, containsString(reqAttr1Atr1Str));
+		assertThat(metadataStr, containsString(reqAttr1Attr2Str));
+		assertThat(metadataStr, containsString(reqAttr2Str));
+		assertThat(metadataStr, containsString(footerStr));
+	}
+
+	/**
+	 * Tests the toAttributeConsumingServicesXml method of Metadata
+	 * Case: single Attribute Consuming Service specified in settings
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 * @see com.onelogin.saml2.settings.Metadata#toAttributeConsumingServicesXml
+	 */
+	@Test
+	public void testToAttributeConsumingServiceXmlMultiACS() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = getSettingFromAllPropertiesMultiACS();
+
+		Metadata metadataObj = new Metadata(settings, null, null);
+		String metadataStr = metadataObj.getMetadataString();
+
+		String header1Str = "<md:AttributeConsumingService index=\"0\">";
+		String sName1Str = "<md:ServiceName xml:lang=\"en\">Just e-mail</md:ServiceName>";
+		String reqAttr11Str = "<md:RequestedAttribute Name=\"Email\" NameFormat=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\" FriendlyName=\"E-mail address\" isRequired=\"true\">";
+		String reqAttr11Atr1Str = "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">foo@example.org</saml:AttributeValue>";
+		String reqAttr11Attr2Str = "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">bar@example.org</saml:AttributeValue>";
+		String footer1Str = "</md:AttributeConsumingService>";
+
+		String header2Str = "<md:AttributeConsumingService index=\"1\" isDefault=\"true\">";
+		String sName2Str = "<md:ServiceName xml:lang=\"it\">Anagrafica</md:ServiceName>";
+		String sDesc2Str = "<md:ServiceDescription xml:lang=\"it\">Servizio completo</md:ServiceDescription>";
+		String reqAttr21Str = "<md:RequestedAttribute Name=\"FirstName\" />";
+		String reqAttr22Str = "<md:RequestedAttribute Name=\"LastName\" isRequired=\"true\" />";
+		String footer2Str = "</md:AttributeConsumingService>";
+
+		assertThat(metadataStr, containsString(header1Str));
+		assertThat(metadataStr, containsString(sName1Str));
+		assertThat(metadataStr, containsString(reqAttr11Str));
+		assertThat(metadataStr, containsString(reqAttr11Atr1Str));
+		assertThat(metadataStr, containsString(reqAttr11Attr2Str));
+		assertThat(metadataStr, containsString(footer1Str));
+
+		assertThat(metadataStr, containsString(header2Str));
+		assertThat(metadataStr, containsString(sName2Str));
+		assertThat(metadataStr, containsString(sDesc2Str));
+		assertThat(metadataStr, containsString(reqAttr21Str));
+		assertThat(metadataStr, containsString(reqAttr22Str));
+		assertThat(metadataStr, containsString(footer2Str));
+		
+		// properties for a single ACS must NOT be present in this case
+		String sNameStr = "<md:ServiceName xml:lang=\"en\">My service</md:ServiceName>";
+		String sDescStr = "<md:ServiceDescription xml:lang=\"en\">My service description</md:ServiceDescription>";
+		String reqAttr1Str = "<md:RequestedAttribute Name=\"Email_Wrong\" NameFormat=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\" FriendlyName=\"E-mail address\" isRequired=\"true\">";
+		String reqAttr1Atr1Str = "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">foo_wrong@example.org</saml:AttributeValue>";
+		String reqAttr1Attr2Str = "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">bar_wrong@example.org</saml:AttributeValue>";
+		String reqAttr2Str = "<md:RequestedAttribute Name=\"FirstName_Wrong\" />";
+
+		assertThat(metadataStr, not(containsString(sNameStr)));
+		assertThat(metadataStr, not(containsString(sDescStr)));
+		assertThat(metadataStr, not(containsString(reqAttr1Str)));
+		assertThat(metadataStr, not(containsString(reqAttr1Atr1Str)));
+		assertThat(metadataStr, not(containsString(reqAttr1Attr2Str)));
+		assertThat(metadataStr, not(containsString(reqAttr2Str)));
 	}
 
 	/**
@@ -460,6 +600,10 @@ public class MetadataTest {
 
 	private Saml2Settings getSettingFromAllProperties() throws Error, IOException {
 		return new SettingsBuilder().fromFile("config/config.all.properties").build();
+	}
+
+	private Saml2Settings getSettingFromAllPropertiesMultiACS() throws Error, IOException {
+		return new SettingsBuilder().fromFile("config/config.all_multi_attribute_consuming_services.properties").build();
 	}
 
 	@Test

--- a/core/src/test/resources/config/config.all_multi_attribute_consuming_services.properties
+++ b/core/src/test/resources/config/config.all_multi_attribute_consuming_services.properties
@@ -31,6 +31,8 @@ onelogin.saml2.sp.single_logout_service.binding = urn:oasis:names:tc:SAML:2.0:bi
 # Take a look on lib/Saml2/Constants.php to see the NameIdFormat supported
 onelogin.saml2.sp.nameidformat = urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 
+# THE FOLLOWING PROPERTIES FOR SINGLE ACS MUST BE IGNORED - MULTIPLE SERVICES DEFINED LATER
+
 # Attribute Consuming Service name when just one ACS should be declared by the SP.
 # Comment out or set to empty if no ACS should be declared, or if multiple ones should (see below). 
 # The service name is mandatory.
@@ -57,13 +59,30 @@ onelogin.saml2.sp.attribute_consuming_service.lang = en
 # Please note that only simple values are currently supported and treated internally as strings. Hence no structured values
 # and no ability to specify an xsi:type attribute. 
 # Attribute values are optional and most often they are simply omitted.
-onelogin.saml2.sp.attribute_consuming_service.attribute[0].name = Email
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].name = Email_Wrong
 onelogin.saml2.sp.attribute_consuming_service.attribute[0].name_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
 onelogin.saml2.sp.attribute_consuming_service.attribute[0].friendly_name = E-mail address
 onelogin.saml2.sp.attribute_consuming_service.attribute[0].required = true
-onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[0] = foo@example.org
-onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[1] = bar@example.org
-onelogin.saml2.sp.attribute_consuming_service.attribute[1].name = FirstName
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[0] = foo_wrong@example.org
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[1] = bar_wrong@example.org
+onelogin.saml2.sp.attribute_consuming_service.attribute[1].name = FirstName_Wrong
+
+# THE FOLLOWING PROPERTIES MUST BE PROCESSED INSTEAD
+
+onelogin.saml2.sp.attribute_consuming_service[0].name = Just e-mail
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].name = Email
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].name_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].friendly_name = E-mail address
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].required = true
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].value[0] = foo@example.org
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].value[1] = bar@example.org
+onelogin.saml2.sp.attribute_consuming_service[1].name = Anagrafica
+onelogin.saml2.sp.attribute_consuming_service[1].description = Servizio completo
+onelogin.saml2.sp.attribute_consuming_service[1].lang = it
+onelogin.saml2.sp.attribute_consuming_service[1].default = true
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[0].name = FirstName
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[1].name = LastName
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[1].required = true
 
 # Usually x509cert and privateKey of the SP are provided by files placed at
 # the certs folder. But we can also provide them with the following parameters

--- a/core/src/test/resources/config/config.min_multi_attribute_consuming_services.properties
+++ b/core/src/test/resources/config/config.min_multi_attribute_consuming_services.properties
@@ -1,0 +1,62 @@
+#  Service Provider Data that we are deploying
+#  Identifier of the SP entity  (must be a URI)
+onelogin.saml2.sp.entityid = http://localhost:8080/java-saml-jspsample/metadata.jsp
+# Specifies info about where and how the <AuthnResponse> message MUST be
+#  returned to the requester, in this case our SP.
+# URL Location where the <Response> from the IdP will be returned
+onelogin.saml2.sp.assertion_consumer_service.url = http://localhost:8080/java-saml-jspsample/acs.jsp
+
+# Specifies info about Logout service
+# URL Location where the <LogoutResponse> from the IdP will be returned or where to send the <LogoutRequest>
+onelogin.saml2.sp.single_logout_service.url = http://localhost:8080/java-saml-jspsample/sls.jsp
+
+# Attributes to be included in the Attribute Consuming Service when just one ACS should be declared by the SP.
+# These are indexed properties, starting from 0. The index is used only to enumerate and sort attributes, but it's required.
+# The following properties allow to define each attribute:
+# - name: mandatory
+# - name_format: optional; if omitted, defaults to urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified
+# - friendly_name: optional; if omitted, it won't appear in SP metadata
+# - required: optional; if omitted or empty, defaults to false
+# - value[x]: an attribute value; the [x] is only used only to enumerate and sort values, but it's required
+# Please note that only simple values are currently supported and treated internally as strings. Hence no structured values
+# and no ability to specify an xsi:type attribute. 
+# Attribute values are optional and most often they are simply omitted.
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].name = Email_Wrong
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].name_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].friendly_name = E-mail address
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].required = true
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[0] = foo_wrong@example.org
+onelogin.saml2.sp.attribute_consuming_service.attribute[0].value[1] = bar_wrong@example.org
+onelogin.saml2.sp.attribute_consuming_service.attribute[1].name = FirstName_Wrong
+
+# THE FOLLOWING PROPERTIES MUST BE PROCESSED INSTEAD
+
+onelogin.saml2.sp.attribute_consuming_service[0].name = Just e-mail
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].name = Email
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].name_format = urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].friendly_name = E-mail address
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].required = true
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].value[0] = foo@example.org
+onelogin.saml2.sp.attribute_consuming_service[0].attribute[0].value[1] = bar@example.org
+onelogin.saml2.sp.attribute_consuming_service[1].name = Anagrafica
+onelogin.saml2.sp.attribute_consuming_service[1].description = Servizio completo
+onelogin.saml2.sp.attribute_consuming_service[1].lang = it
+onelogin.saml2.sp.attribute_consuming_service[1].default = true
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[0].name = FirstName
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[1].name = LastName
+onelogin.saml2.sp.attribute_consuming_service[1].attribute[1].required = true
+
+# Identity Provider Data that we want connect with our SP
+# Identifier of the IdP entity  (must be a URI)
+onelogin.saml2.idp.entityid = http://idp.example.com/
+
+# SSO endpoint info of the IdP. (Authentication Request protocol)
+# URL Target of the IdP where the SP will send the Authentication Request Message
+onelogin.saml2.idp.single_sign_on_service.url = http://idp.example.com/simplesaml/saml2/idp/SSOService.php
+
+# SLO endpoint info of the IdP.
+# URL Location of the IdP where the SP will send the SLO Request
+onelogin.saml2.idp.single_logout_service.url = http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php
+
+# Public x509 certificate of the IdP
+onelogin.saml2.idp.x509cert = -----BEGIN CERTIFICATE-----\nMIIBrTCCAaGgAwIBAgIBATADBgEAMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMB4XDTEwMTAxMTIxMTUxMloXDTE1MTAxMTIxMTUxMlowZzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFTATBgNVBAcMDFNhbnRhIE1vbmljYTERMA8GA1UECgwIT25lTG9naW4xGTAXBgNVBAMMEGFwcC5vbmVsb2dpbi5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMPmjfjy7L35oDpeBXBoRVCgktPkLno9DOEWB7MgYMMVKs2B6ymWQLEWrDugMK1hkzWFhIb5fqWLGbWy0J0veGR9/gHOQG+rD/I36xAXnkdiXXhzoiAG/zQxM0edMOUf40n314FC8moErcUg6QabttzesO59HFz6shPuxcWaVAgxAgMBAAEwAwYBAAMBAA==\n-----END CERTIFICATE-----

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.onelogin.saml2.authn.AuthnRequest;
+import com.onelogin.saml2.authn.AuthnRequestParams;
 import com.onelogin.saml2.authn.SamlResponse;
 import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.exception.Error;
@@ -310,63 +311,232 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 * @param stay            True if we want to stay (returns the url string) False
-	 *                        to execute redirection
-	 * @param nameIdValueReq  Indicates to the IdP the subject that should be
-	 *                        authenticated
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameIdValueReq
+	 *              Indicates to the IdP the subject that should be authenticated
 	 *
 	 * @return the SSO URL with the AuthNRequest if stay = True
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #login(String, AuthnRequestParams, Boolean)} with
+	 *             {@link AuthnRequestParams#AuthnRequestParams(boolean, boolean, boolean, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
 			String nameIdValueReq) throws IOException, SettingsException {
 		Map<String, String> parameters = new HashMap<String, String>();
-		return login(returnTo, forceAuthn, isPassive, setNameIdPolicy, stay,
-				nameIdValueReq, parameters);
+		return login(returnTo, new AuthnRequestParams(forceAuthn, isPassive, setNameIdPolicy, nameIdValueReq), stay,
+		            parameters);
 	}
 
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 * @param stay            True if we want to stay (returns the url string) False
-	 *                        to execute redirection
-	 * @param nameIdValueReq  Indicates to the IdP the subject that should be
-	 *                        authenticated
-	 * @param parameters      Use it to send extra parameters in addition to the AuthNRequest
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameIdValueReq
+	 *              Indicates to the IdP the subject that should be authenticated
+	 * @param parameters
+	 *              Use it to send extra parameters in addition to the AuthNRequest
+	 *
+	 * @return the SSO URL with the AuthNRequest if stay = True
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 * @deprecated use {@link #login(String, AuthnRequestParams, Boolean, Map)} with
+	 *             {@link AuthnRequestParams#AuthnRequestParams(boolean, boolean, boolean, String)}
+	 *             instead
+	 */
+	@Deprecated
+	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
+			String nameIdValueReq, Map<String, String> parameters) throws IOException, SettingsException {
+		return login(returnTo, new AuthnRequestParams(forceAuthn, isPassive, setNameIdPolicy, nameIdValueReq), stay,
+		            parameters);
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 *
+	 * @return the SSO URL with the AuthNRequest if stay = True
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 * @deprecated use {@link #login(String, AuthnRequestParams, Boolean)} with
+	 *             {@link AuthnRequestParams#AuthnRequestParams(boolean, boolean, boolean)}
+	 *             instead
+	 */
+	@Deprecated
+	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay)
+			throws IOException, SettingsException {
+		return login(returnTo, new AuthnRequestParams(forceAuthn, isPassive, setNameIdPolicy), stay, null);
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 * @deprecated use {@link #login(String, AuthnRequestParams)} with
+	 *             {@link AuthnRequestParams#AuthnRequestParams(boolean, boolean, boolean)}
+	 *             instead
+	 */
+	@Deprecated
+	public void login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy)
+			throws IOException, SettingsException {
+		login(returnTo, new AuthnRequestParams(forceAuthn, isPassive, setNameIdPolicy), false);
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 */
+	public void login() throws IOException, SettingsException {
+		login(null, new AuthnRequestParams(false, false, true));
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param authnRequestParams
+	 *              the authentication request input parameters
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 */
+	public void login(AuthnRequestParams authnRequestParams) throws IOException, SettingsException {
+		login(null, authnRequestParams);
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param returnTo The target URL the user should be returned to after login
+	 *                 (relayState). Will be a self-routed URL when null, or not be
+	 *                 appended at all when an empty string is provided.
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 */
+	public void login(String returnTo) throws IOException, SettingsException {
+		login(returnTo, new AuthnRequestParams(false, false, true));
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param authnRequestParams
+	 *              the authentication request input parameters
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 */
+	public void login(String returnTo, AuthnRequestParams authnRequestParams) throws IOException, SettingsException {
+		login(returnTo, authnRequestParams, false);
+	}
+
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param authnRequestParams
+	 *              the authentication request input parameters
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
 	 *
 	 * @return the SSO URL with the AuthNRequest if stay = True
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
-			String nameIdValueReq, Map<String, String> parameters) throws IOException, SettingsException {
-		AuthnRequest authnRequest = new AuthnRequest(settings, forceAuthn, isPassive, setNameIdPolicy, nameIdValueReq);
+	public String login(String returnTo, AuthnRequestParams authnRequestParams, Boolean stay) throws IOException, SettingsException {
+		return login(returnTo, authnRequestParams, stay, new HashMap<>());
+	}
 
+	/**
+	 * Initiates the SSO process.
+	 *
+	 * @param returnTo
+	 *              The target URL the user should be returned to after login
+	 *              (relayState). Will be a self-routed URL when null, or not be
+	 *              appended at all when an empty string is provided
+	 * @param authnRequestParams
+	 *              the authentication request input parameters
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param parameters
+	 *              Use it to send extra parameters in addition to the AuthNRequest
+	 *
+	 * @return the SSO URL with the AuthNRequest if stay = True
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 */
+	public String login(String returnTo, AuthnRequestParams authnRequestParams, Boolean stay, Map<String, String> parameters) throws IOException, SettingsException {
 		if (parameters == null) {
 			parameters = new HashMap<String, String>();
 		}
-
+		AuthnRequest authnRequest = new AuthnRequest(settings, authnRequestParams);
 		String samlRequest = authnRequest.getEncodedAuthnRequest();
 
 		parameters.put("SAMLRequest", samlRequest);
@@ -398,76 +568,6 @@ public class Auth {
 			LOGGER.debug("AuthNRequest sent to " + ssoUrl + " --> " + samlRequest);
 		}
 		return ServletUtils.sendRedirect(response, ssoUrl, parameters, stay);
-	}
-
-	/**
-	 * Initiates the SSO process.
-	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 * @param stay            True if we want to stay (returns the url string) False
-	 *                        to execute redirection
-	 *
-	 * @return the SSO URL with the AuthNRequest if stay = True
-	 *
-	 * @throws IOException
-	 * @throws SettingsException
-	 */
-	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay)
-			throws IOException, SettingsException {
-		return login(returnTo, forceAuthn, isPassive, setNameIdPolicy, stay, null);
-	}
-
-	/**
-	 * Initiates the SSO process.
-	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 *
-	 * @throws IOException
-	 * @throws SettingsException
-	 */
-	public void login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy)
-			throws IOException, SettingsException {
-		login(returnTo, forceAuthn, isPassive, setNameIdPolicy, false);
-	}
-
-	/**
-	 * Initiates the SSO process.
-	 *
-	 * @throws IOException
-	 * @throws SettingsException
-	 */
-	public void login() throws IOException, SettingsException {
-		login(null, false, false, true);
-	}
-
-	/**
-	 * Initiates the SSO process.
-	 *
-	 * @param returnTo The target URL the user should be returned to after login
-	 *                 (relayState). Will be a self-routed URL when null, or not be
-	 *                 appended at all when an empty string is provided.
-	 *
-	 * @throws IOException
-	 * @throws SettingsException
-	 */
-	public void login(String returnTo) throws IOException, SettingsException {
-		login(returnTo, false, false, true);
 	}
 
 	/**

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -42,20 +42,20 @@ import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
 
 import com.onelogin.saml2.Auth;
+import com.onelogin.saml2.authn.AuthnRequestParams;
 import com.onelogin.saml2.exception.Error;
-import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.exception.SettingsException;
+import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.model.KeyStoreSettings;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
-
-import org.mockito.ArgumentCaptor;
-import org.w3c.dom.Document;
 
 public class AuthTest {
 
@@ -1380,7 +1380,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		Map<String, String> extraParameters = new HashMap<String, String>();
 		extraParameters.put("parameter1", "xxx");
-		String target = auth.login("", false, false, false, true, null, extraParameters);
+		String target = auth.login("", new AuthnRequestParams(false, false, false), true, extraParameters);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		assertThat(target, containsString("&parameter1=xxx"));
 	}
@@ -1409,12 +1409,12 @@ public class AuthTest {
 		settings.setAuthnRequestsSigned(false);
 
 		Auth auth = new Auth(settings, request, response);
-		String target = auth.login("", false, false, false, true);
+		String target = auth.login("", new AuthnRequestParams(false, false, false), true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		assertThat(target, not(containsString("&RelayState=")));
 
 		String relayState = "http://localhost:8080/expected.jsp";
-		target = auth.login(relayState, false, false, false, true);
+		target = auth.login(relayState, new AuthnRequestParams(false, false, false), true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		assertThat(target, containsString("&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp"));		
 	}
@@ -1442,13 +1442,13 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
-		String target = auth.login("", false, false, false, true);
+		String target = auth.login("", new AuthnRequestParams(false, false, false), true);
 		assertThat(target, startsWith("http://idp.example.com/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		String authNRequestStr = getSAMLRequestFromURL(target);
 		assertThat(authNRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authNRequestStr, not(containsString("<saml:Subject")));
 
-		target = auth.login("", false, false, false, true, "testuser@example.com");
+		target = auth.login("", new AuthnRequestParams(false, false, false, "testuser@example.com"), true);
 		assertThat(target, startsWith("http://idp.example.com/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		authNRequestStr = getSAMLRequestFromURL(target);
 		assertThat(authNRequestStr, containsString("<samlp:AuthnRequest"));
@@ -1458,7 +1458,7 @@ public class AuthTest {
 
 		settings = new SettingsBuilder().fromFile("config/config.emailaddressformat.properties").build();
 		auth = new Auth(settings, request, response);
-		target = auth.login("", false, false, false, true, "testuser@example.com");
+		target = auth.login("", new AuthnRequestParams(false, false, false, "testuser@example.com"), true);
 		assertThat(target, startsWith("http://idp.example.com/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		authNRequestStr = getSAMLRequestFromURL(target);
 		assertThat(authNRequestStr, containsString("<samlp:AuthnRequest"));
@@ -2085,7 +2085,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
-		String targetSSOURL = auth.login(null, false, false, false, true);
+		String targetSSOURL = auth.login(null, new AuthnRequestParams(false, false, false), true);
 		String authNRequestXML = auth.getLastRequestXML();
 		assertThat(targetSSOURL, containsString(Util.urlEncoder(Util.deflatedBase64encoded(authNRequestXML))));
 	}


### PR DESCRIPTION
Attribute Consuming Services can now be configured in settings. They will then be parsed and added to the generated metadata. On SSO initiation a selector mechanism can be used to select the desired ACS, producing the proper AttributeConsumingServiceIndex attribute in the AuthnRequest.

This is what I add in mind when I wrote https://github.com/onelogin/java-saml/issues/264#issuecomment-787953617. To quickly understand the rationale, I suggest to start to look at the changes made to the README file.
All changes are backward compatible, although I've deprecated some method overloadings because I think they are now obsolete and pollute the code (see, for instance, the so many overloadings of `Auth.login()` method). To better shape the login input parameters, I introduced a `AuthnRequest` superclass, named `AuthnRequestParams` that just carry information on how the `AuthnRequest` should be produced, without any reference to the settings, to the binding protocol or to other context-related information. Then, `AuthnRequest` extends `AuthnRequestParams` to easily use those input parameters and maintain backward compatibility. If in future any more input params are to be introduced, they can be added to `AuthnRequestParams` without the need to even further overload `Auth.login()` (I was thinking about the ability to select an Assertion Consumer Services among a set of available services, somewhat similar to what I made now with Attribute Consuming Services).

I tested my changes by adding some more tests and by using it in an application I'm writing. As I said in #264, these changes are particularly useful to properly support the Italian SPID authentication system.

I tried to adhere as much as possible to the existing styles of code formatting and javadoc, but it was not easy because I see there are multiple styles in place.