### PR TITLE
SamlSettings created from Properties only parses string values

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -786,7 +786,7 @@ public class SettingsBuilder {
 	 */
 	private void parseProperties(Properties properties) {
 		if (properties != null) {
-			for (String propertyKey : properties.stringPropertyNames()) {
+			for (String propertyKey : properties.propertyNames()) {
 				this.samlData.put(propertyKey, properties.getProperty(propertyKey));
 			}
 		}


### PR DESCRIPTION
SamlSettings created from Properties only parses string values
Properties instance can be created by reading a .properties file or in java code. If properties built using code continue values other than strings like boolean certificates etc then the Settings builder does not process them. 

Approach here is to process all properties 