### PR TITLE
Clarify the real nature of the RelayState parameter for SSO and SLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,10 +433,10 @@ The AuthNRequest will be sent signed or unsigned based on the security settings 
 
 The IdP will then return the SAML Response to the user's client. The client is then forwarded to the Attribute Consumer Service of the SP with this information.
 
-We can set a 'returnTo' url parameter to the login function and that will be converted as a 'RelayState' parameter:
+We can set a 'RelayState' parameter containing a return url to the login function:
 ```
-String targetUrl = 'https://example.com';
-auth.login(returnTo=targetUrl)
+String returnUrl = 'https://example.com';
+auth.login(relayState=returnUrl)
 ```
 The login method can receive 6 more optional parameters:
 - *forceAuthn* When true the AuthNRequest will have the 'ForceAuthn' attribute set to 'true'
@@ -605,10 +605,10 @@ The Logout Request will be sent signed or unsigned based on the security setting
 
 The IdP will return the Logout Response through the user's client to the Single Logout Service of the SP.
 
-We can set a 'returnTo' url parameter to the logout function and that will be converted as a 'RelayState' parameter:
+We can set a 'RelayState' parameter containing a return url to the login function:
 ```
-String targetUrl = 'https://example.com';
-auth.logout(returnTo=targetUrl)
+String returnUrl = 'https://example.com';
+auth.logout(relayState=returnUrl)
 ```
 
 Also there are 7 optional parameters that can be set:

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -310,10 +310,19 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
+	 * @param relayState      a state information to pass forth and back between
+	 * 				  the Service Provider and the Identity Provider; 
+	 * 				  in the most simple case, it may be a URL to which
+	 * 				  the authenticated user should be redirected after the
+	 * 				  authentication response has been received back from the 
+	 * 				  Identity Provider and validated correctly with
+	 * 				  {@link #processResponse()}; please note that SAML 2.0 
+	 * 				  specification imposes a limit of max 80 characters for 
+	 * 				  this relayState data and that protection strategies 
+	 * 				  against tampering should better be implemented;
+	 * 				  it will be a self-routed URL when <code>null</code>, 
+	 * 				  otherwise no relayState at all will be appended if an empty 
+	 * 				  string is provided
 	 * @param forceAuthn      When true the AuthNRequest will set the
 	 *                        ForceAuthn='true'
 	 * @param isPassive       When true the AuthNRequest will set the
@@ -329,20 +338,29 @@ public class Auth {
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
+	public String login(String relayState, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
 			String nameIdValueReq) throws IOException, SettingsException {
 		Map<String, String> parameters = new HashMap<String, String>();
-		return login(returnTo, forceAuthn, isPassive, setNameIdPolicy, stay,
+		return login(relayState, forceAuthn, isPassive, setNameIdPolicy, stay,
 				nameIdValueReq, parameters);
 	}
 
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
+	 * @param relayState      a state information to pass forth and back between
+	 * 				  the Service Provider and the Identity Provider; 
+	 * 				  in the most simple case, it may be a URL to which
+	 * 				  the authenticated user should be redirected after the
+	 * 				  authentication response has been received back from the 
+	 * 				  Identity Provider and validated correctly with
+	 * 				  {@link #processResponse()}; please note that SAML 2.0 
+	 * 				  specification imposes a limit of max 80 characters for 
+	 * 				  this relayState data and that protection strategies 
+	 * 				  against tampering should better be implemented;
+	 * 				  it will be a self-routed URL when <code>null</code>, 
+	 * 				  otherwise no relayState at all will be appended if an empty 
+	 * 				  string is provided
 	 * @param forceAuthn      When true the AuthNRequest will set the
 	 *                        ForceAuthn='true'
 	 * @param isPassive       When true the AuthNRequest will set the
@@ -359,7 +377,7 @@ public class Auth {
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
+	public String login(String relayState, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay,
 			String nameIdValueReq, Map<String, String> parameters) throws IOException, SettingsException {
 		AuthnRequest authnRequest = new AuthnRequest(settings, forceAuthn, isPassive, setNameIdPolicy, nameIdValueReq);
 
@@ -371,11 +389,8 @@ public class Auth {
 
 		parameters.put("SAMLRequest", samlRequest);
 
-		String relayState;
-		if (returnTo == null) {
+		if (relayState == null) {
 			relayState = ServletUtils.getSelfRoutedURLNoQuery(request);
-		} else {
-			relayState = returnTo;
 		}
 
 		if (!relayState.isEmpty()) {
@@ -403,10 +418,19 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
+	 * @param relayState      a state information to pass forth and back between
+	 * 				  the Service Provider and the Identity Provider; 
+	 * 				  in the most simple case, it may be a URL to which
+	 * 				  the authenticated user should be redirected after the
+	 * 				  authentication response has been received back from the 
+	 * 				  Identity Provider and validated correctly with
+	 * 				  {@link #processResponse()}; please note that SAML 2.0 
+	 * 				  specification imposes a limit of max 80 characters for 
+	 * 				  this relayState data and that protection strategies 
+	 * 				  against tampering should better be implemented;
+	 * 				  it will be a self-routed URL when <code>null</code>, 
+	 * 				  otherwise no relayState at all will be appended if an empty 
+	 * 				  string is provided
 	 * @param forceAuthn      When true the AuthNRequest will set the
 	 *                        ForceAuthn='true'
 	 * @param isPassive       When true the AuthNRequest will set the
@@ -420,18 +444,27 @@ public class Auth {
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public String login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay)
+	public String login(String relayState, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy, Boolean stay)
 			throws IOException, SettingsException {
-		return login(returnTo, forceAuthn, isPassive, setNameIdPolicy, stay, null);
+		return login(relayState, forceAuthn, isPassive, setNameIdPolicy, stay, null);
 	}
 
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo        The target URL the user should be returned to after
-	 *                        login (relayState). Will be a self-routed URL when
-	 *                        null, or not be appended at all when an empty string
-	 *                        is provided
+	 * @param relayState      a state information to pass forth and back between
+	 * 				  the Service Provider and the Identity Provider; 
+	 * 				  in the most simple case, it may be a URL to which
+	 * 				  the authenticated user should be redirected after the
+	 * 				  authentication response has been received back from the 
+	 * 				  Identity Provider and validated correctly with
+	 * 				  {@link #processResponse()}; please note that SAML 2.0 
+	 * 				  specification imposes a limit of max 80 characters for 
+	 * 				  this relayState data and that protection strategies 
+	 * 				  against tampering should better be implemented;
+	 * 				  it will be a self-routed URL when <code>null</code>, 
+	 * 				  otherwise no relayState at all will be appended if an empty 
+	 * 				  string is provided
 	 * @param forceAuthn      When true the AuthNRequest will set the
 	 *                        ForceAuthn='true'
 	 * @param isPassive       When true the AuthNRequest will set the
@@ -441,9 +474,9 @@ public class Auth {
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public void login(String returnTo, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy)
+	public void login(String relayState, Boolean forceAuthn, Boolean isPassive, Boolean setNameIdPolicy)
 			throws IOException, SettingsException {
-		login(returnTo, forceAuthn, isPassive, setNameIdPolicy, false);
+		login(relayState, forceAuthn, isPassive, setNameIdPolicy, false);
 	}
 
 	/**
@@ -459,24 +492,43 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param returnTo The target URL the user should be returned to after login
-	 *                 (relayState). Will be a self-routed URL when null, or not be
-	 *                 appended at all when an empty string is provided.
+	 * @param relayState a state information to pass forth and back between
+	 * 			   the Service Provider and the Identity Provider; 
+	 * 			   in the most simple case, it may be a URL to which
+	 * 			   the authenticated user should be redirected after the
+	 * 			   authentication response has been received back from the 
+	 * 			   Identity Provider and validated correctly with
+	 * 			   {@link #processResponse()}; please note that SAML 2.0 
+	 * 			   specification imposes a limit of max 80 characters for 
+	 * 			   this relayState data and that protection strategies 
+	 * 			   against tampering should better be implemented;
+	 * 			   it will be a self-routed URL when <code>null</code>, 
+	 * 			   otherwise no relayState at all will be appended if an empty 
+	 * 			   string is provided
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public void login(String returnTo) throws IOException, SettingsException {
-		login(returnTo, false, false, true);
+	public void login(String relayState) throws IOException, SettingsException {
+		login(relayState, false, false, true);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo              The target URL the user should be returned to
-	 *                              after logout (relayState). Will be a self-routed
-	 *                              URL when null, or not be appended at all when an
-	 *                              empty string is provided
+	 * @param relayState      	  a state information to pass forth and back between
+	 * 				  	  the Service Provider and the Identity Provider; 
+	 * 				  	  in the most simple case, it may be a URL to which
+	 * 				  	  the logged out user should be redirected after the
+	 * 				  	  logout response has been received back from the 
+	 * 				  	  Identity Provider and validated correctly with
+	 * 				  	  {@link #processSLO()}; please note that SAML 2.0 
+	 * 				  	  specification imposes a limit of max 80 characters for 
+	 * 				  	  this relayState data and that protection strategies 
+	 * 				  	  against tampering should better be implemented;
+	 * 				  	  it will be a self-routed URL when <code>null</code>, 
+	 * 				  	  otherwise no relayState at all will be appended if an empty 
+	 * 				  	  string is provided
 	 * @param nameId                The NameID that will be set in the
 	 *                              LogoutRequest.
 	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
@@ -496,21 +548,30 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier)
 			throws IOException, XMLEntityException, SettingsException {
 		Map<String, String> parameters = new HashMap<String, String>();
-		return logout(returnTo, nameId, sessionIndex, stay, nameidFormat,
+		return logout(relayState, nameId, sessionIndex, stay, nameidFormat,
 				nameIdNameQualifier, nameIdSPNameQualifier, parameters);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo              The target URL the user should be returned to
-	 *                              after logout (relayState). Will be a self-routed
-	 *                              URL when null, or not be appended at all when an
-	 *                              empty string is provided
+	 * @param relayState      	  a state information to pass forth and back between
+	 * 				  	  the Service Provider and the Identity Provider; 
+	 * 				  	  in the most simple case, it may be a URL to which
+	 * 				  	  the logged out user should be redirected after the
+	 * 				  	  logout response has been received back from the 
+	 * 				  	  Identity Provider and validated correctly with
+	 * 				  	  {@link #processSLO()}; please note that SAML 2.0 
+	 * 				  	  specification imposes a limit of max 80 characters for 
+	 * 				  	  this relayState data and that protection strategies 
+	 * 				  	  against tampering should better be implemented;
+	 * 				  	  it will be a self-routed URL when <code>null</code>, 
+	 * 				  	  otherwise no relayState at all will be appended if an empty 
+	 * 				  	  string is provided
 	 * @param nameId                The NameID that will be set in the
 	 *                              LogoutRequest.
 	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
@@ -523,7 +584,7 @@ public class Auth {
 	 *                              LogoutRequest.
 	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
 	 *                              the LogoutRequest.
-	 * @param parameters      		Use it to send extra parameters in addition to the LogoutRequest
+	 * @param parameters      	  Use it to send extra parameters in addition to the LogoutRequest
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
@@ -531,7 +592,7 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier, Map<String, String> parameters)
 			throws IOException, XMLEntityException, SettingsException {
 
@@ -544,11 +605,8 @@ public class Auth {
 		String samlLogoutRequest = logoutRequest.getEncodedLogoutRequest();
 		parameters.put("SAMLRequest", samlLogoutRequest);
 
-		String relayState;
-		if (returnTo == null) {
+		if (relayState == null) {
 			relayState = ServletUtils.getSelfRoutedURLNoQuery(request);
-		} else {
-			relayState = returnTo;
 		}
 
 		if (!relayState.isEmpty()) {
@@ -576,10 +634,19 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo            The target URL the user should be returned to
-	 *                            after logout (relayState). Will be a self-routed
-	 *                            URL when null, or not be appended at all when an
-	 *                            empty string is provided
+	 * @param relayState      	a state information to pass forth and back between
+	 * 				  	the Service Provider and the Identity Provider; 
+	 * 				  	in the most simple case, it may be a URL to which
+	 * 				  	the logged out user should be redirected after the
+	 * 				  	logout response has been received back from the 
+	 * 				  	Identity Provider and validated correctly with
+	 * 				  	{@link #processSLO()}; please note that SAML 2.0 
+	 * 				  	specification imposes a limit of max 80 characters for 
+	 * 				  	this relayState data and that protection strategies 
+	 * 				  	against tampering should better be implemented;
+	 * 				  	it will be a self-routed URL when <code>null</code>, 
+	 * 				  	otherwise no relayState at all will be appended if an empty 
+	 * 				  	string is provided
 	 * @param nameId              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex        The SessionIndex (taken from the SAML Response in
 	 *                            the SSO process).
@@ -596,18 +663,27 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
 			String nameIdNameQualifier) throws IOException, XMLEntityException, SettingsException {
-		return logout(returnTo, nameId, sessionIndex, stay, nameidFormat, nameIdNameQualifier, null);
+		return logout(relayState, nameId, sessionIndex, stay, nameidFormat, nameIdNameQualifier, null);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo     The target URL the user should be returned to after
-	 *                     logout (relayState). Will be a self-routed URL when null,
-	 *                     or not be appended at all when an empty string is
-	 *                     provided
+	 * @param relayState   a state information to pass forth and back between
+	 * 			     the Service Provider and the Identity Provider; 
+	 * 			     in the most simple case, it may be a URL to which
+	 * 			     the logged out user should be redirected after the
+	 * 			     logout response has been received back from the 
+	 * 			     Identity Provider and validated correctly with
+	 * 			     {@link #processSLO()}; please note that SAML 2.0 
+	 * 			     specification imposes a limit of max 80 characters for 
+	 * 			     this relayState data and that protection strategies 
+	 * 			     against tampering should better be implemented;
+	 * 			     it will be a self-routed URL when <code>null</code>, 
+	 * 			     otherwise no relayState at all will be appended if an empty 
+	 * 			     string is provided
 	 * @param nameId       The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
 	 *                     process).
@@ -621,18 +697,27 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat)
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat)
 			throws IOException, XMLEntityException, SettingsException {
-		return logout(returnTo, nameId, sessionIndex, stay, nameidFormat, null);
+		return logout(relayState, nameId, sessionIndex, stay, nameidFormat, null);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo     The target URL the user should be returned to after
-	 *                     logout (relayState). Will be a self-routed URL when null,
-	 *                     or not be appended at all when an empty string is
-	 *                     provided
+	 * @param relayState   a state information to pass forth and back between
+	 * 			     the Service Provider and the Identity Provider; 
+	 * 			     in the most simple case, it may be a URL to which
+	 * 			     the logged out user should be redirected after the
+	 * 			     logout response has been received back from the 
+	 * 			     Identity Provider and validated correctly with
+	 * 			     {@link #processSLO()}; please note that SAML 2.0 
+	 * 			     specification imposes a limit of max 80 characters for 
+	 * 			     this relayState data and that protection strategies 
+	 * 			     against tampering should better be implemented;
+	 * 			     it will be a self-routed URL when <code>null</code>, 
+	 * 			     otherwise no relayState at all will be appended if an empty 
+	 * 			     string is provided
 	 * @param nameId       The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
 	 *                     process).
@@ -645,18 +730,27 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay)
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay)
 			throws IOException, XMLEntityException, SettingsException {
-		return logout(returnTo, nameId, sessionIndex, stay, null);
+		return logout(relayState, nameId, sessionIndex, stay, null);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo              The target URL the user should be returned to
-	 *                              after logout (relayState). Will be a self-routed
-	 *                              URL when null, or not be appended at all when an
-	 *                              empty string is provided
+	 * @param relayState   		  a state information to pass forth and back between
+	 * 			     		  the Service Provider and the Identity Provider; 
+	 * 			     		  in the most simple case, it may be a URL to which
+	 * 			     		  the logged out user should be redirected after the
+	 * 			     		  logout response has been received back from the 
+	 * 			     		  Identity Provider and validated correctly with
+	 * 			     		  {@link #processSLO()}; please note that SAML 2.0 
+	 * 			     		  specification imposes a limit of max 80 characters for 
+	 * 			     		  this relayState data and that protection strategies 
+	 * 			     		  against tampering should better be implemented;
+	 * 			     		  it will be a self-routed URL when <code>null</code>, 
+	 * 			     		  otherwise no relayState at all will be appended if an empty 
+	 * 			     		  string is provided
 	 * @param nameId                The NameID that will be set in the
 	 *                              LogoutRequest.
 	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
@@ -671,19 +765,28 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout(String returnTo, String nameId, String sessionIndex, String nameidFormat,
+	public void logout(String relayState, String nameId, String sessionIndex, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier)
 			throws IOException, XMLEntityException, SettingsException {
-		logout(returnTo, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier);
+		logout(relayState, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo            The target URL the user should be returned to
-	 *                            after logout (relayState). Will be a self-routed
-	 *                            URL when null, or not be appended at all when an
-	 *                            empty string is provided
+	 * @param relayState   		a state information to pass forth and back between
+	 * 			     		the Service Provider and the Identity Provider; 
+	 * 			     		in the most simple case, it may be a URL to which
+	 * 			     		the logged out user should be redirected after the
+	 * 			     		logout response has been received back from the 
+	 * 			     		Identity Provider and validated correctly with
+	 * 			     		{@link #processSLO()}; please note that SAML 2.0 
+	 * 			     		specification imposes a limit of max 80 characters for 
+	 * 			     		this relayState data and that protection strategies 
+	 * 			     		against tampering should better be implemented;
+	 * 			     		it will be a self-routed URL when <code>null</code>, 
+	 * 			     		otherwise no relayState at all will be appended if an empty 
+	 * 			     		string is provided
 	 * @param nameId              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex        The SessionIndex (taken from the SAML Response in
 	 *                            the SSO process).
@@ -696,18 +799,27 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout(String returnTo, String nameId, String sessionIndex, String nameidFormat,
+	public void logout(String relayState, String nameId, String sessionIndex, String nameidFormat,
 			String nameIdNameQualifier) throws IOException, XMLEntityException, SettingsException {
-		logout(returnTo, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier);
+		logout(relayState, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo     The target URL the user should be returned to after
-	 *                     logout (relayState). Will be a self-routed URL when null,
-	 *                     or not be appended at all when an empty string is
-	 *                     provided
+	 * @param relayState a state information to pass forth and back between
+	 * 			   the Service Provider and the Identity Provider; 
+	 * 			   in the most simple case, it may be a URL to which
+	 * 			   the logged out user should be redirected after the
+	 * 			   logout response has been received back from the 
+	 * 			   Identity Provider and validated correctly with
+	 * 			   {@link #processSLO()}; please note that SAML 2.0 
+	 * 			   specification imposes a limit of max 80 characters for 
+	 * 			   this relayState data and that protection strategies 
+	 * 			   against tampering should better be implemented;
+	 * 			   it will be a self-routed URL when <code>null</code>, 
+	 * 			   otherwise no relayState at all will be appended if an empty 
+	 * 			   string is provided
 	 * @param nameId       The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
 	 *                     process).
@@ -716,18 +828,27 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout(String returnTo, String nameId, String sessionIndex, String nameidFormat)
+	public void logout(String relayState, String nameId, String sessionIndex, String nameidFormat)
 			throws IOException, XMLEntityException, SettingsException {
-		logout(returnTo, nameId, sessionIndex, false, nameidFormat);
+		logout(relayState, nameId, sessionIndex, false, nameidFormat);
 	}
 
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo     The target URL the user should be returned to after
-	 *                     logout (relayState). Will be a self-routed URL when null,
-	 *                     or not be appended at all when an empty string is
-	 *                     provided
+	 * @param relayState   a state information to pass forth and back between
+	 * 			     the Service Provider and the Identity Provider; 
+	 * 			     in the most simple case, it may be a URL to which
+	 * 			     the logged out user should be redirected after the
+	 * 			     logout response has been received back from the 
+	 * 			     Identity Provider and validated correctly with
+	 * 			     {@link #processSLO()}; please note that SAML 2.0 
+	 * 			     specification imposes a limit of max 80 characters for 
+	 * 			     this relayState data and that protection strategies 
+	 * 			     against tampering should better be implemented;
+	 * 			     it will be a self-routed URL when <code>null</code>, 
+	 * 			     otherwise no relayState at all will be appended if an empty 
+	 * 			     string is provided
 	 * @param nameId       The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
 	 *                     process).
@@ -736,9 +857,9 @@ public class Auth {
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout(String returnTo, String nameId, String sessionIndex)
+	public void logout(String relayState, String nameId, String sessionIndex)
 			throws IOException, XMLEntityException, SettingsException {
-		logout(returnTo, nameId, sessionIndex, false, null);
+		logout(relayState, nameId, sessionIndex, false, null);
 	}
 
 	/**
@@ -755,16 +876,26 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param returnTo The target URL the user should be returned to after logout
-	 *                 (relayState). Will be a self-routed URL when null, or not be
-	 *                 appended at all when an empty string is provided
+	 * @param relayState a state information to pass forth and back between
+	 * 			   the Service Provider and the Identity Provider; 
+	 * 			   in the most simple case, it may be a URL to which
+	 * 			   the logged out user should be redirected after the
+	 * 			   logout response has been received back from the 
+	 * 			   Identity Provider and validated correctly with
+	 * 			   {@link #processSLO()}; please note that SAML 2.0 
+	 * 			   specification imposes a limit of max 80 characters for 
+	 * 			   this relayState data and that protection strategies 
+	 * 			   against tampering should better be implemented;
+	 * 			   it will be a self-routed URL when <code>null</code>, 
+	 * 			   otherwise no relayState at all will be appended if an empty 
+	 * 			   string is provided
 	 *
 	 * @throws IOException
 	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout(String returnTo) throws IOException, XMLEntityException, SettingsException {
-		logout(returnTo, null, null);
+	public void logout(String relayState) throws IOException, XMLEntityException, SettingsException {
+		logout(relayState, null, null);
 	}
 
 	/**


### PR DESCRIPTION
I know this might be considered an opinionated cosmetic change, but please read on the rationale behind this renaming.

In the most simple case, the RelayState may be used as a "returnUrl",
but I think it's important to underline that the RelayState does not
necessarily need to be a return URL. Indeed, the SAML 2.0 specification
clarifies that a limit of max 80 characters exists for it (at least
in the case of the HTTP-Redirect binding) and that a protection method
against tampering is suggested.
Therefore, a return URL in general would probably be a non-ideal use of
the RelayState parameter, so let's give the latter the relevance it
deserves.