### PR TITLE
Make SamlResponse more extensible

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -1022,6 +1022,17 @@ public class SamlResponse {
 	public Exception getValidationException() {
 		return validationException;
 	}
+	
+	/**
+	 * Sets the validation exception that this {@link SamlResponse} should return
+	 * when a validation error occurs.
+	 * 
+	 * @param validationException
+	 *              the validation exception to set
+	 */
+	protected void setValidationException(Exception validationException) {
+		this.validationException = validationException;
+	}
 
 	/**
 	 * Extracts a node from the DOMDocument (Assertion).

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -1033,7 +1033,7 @@ public class SamlResponse {
 	 * @throws XPathExpressionException
 	 *
 	 */
-	private NodeList queryAssertion(String assertionXpath) throws XPathExpressionException {
+	protected NodeList queryAssertion(String assertionXpath) throws XPathExpressionException {
         final String assertionExpr = "/saml:Assertion";
         final String signatureExpr = "ds:Signature/ds:SignedInfo/ds:Reference";
 
@@ -1084,16 +1084,9 @@ public class SamlResponse {
      *
      * @return DOMNodeList The queried nodes
      */
-	private NodeList query(String nameQuery, Node context) throws XPathExpressionException {
-		Document doc;
-		if (encrypted) {
-			doc = decryptedDocument;
-		} else {
-        	doc = samlResponseDocument;
-		}
-
+	protected NodeList query(String nameQuery, Node context) throws XPathExpressionException {
 		// LOGGER.debug("Executing query " + nameQuery);
-		return Util.query(doc, nameQuery, context);
+		return Util.query(getSAMLResponseDocument(), nameQuery, context);
 	}
 
 	/**


### PR DESCRIPTION
The query and queryAssertion methods are really useful when creating
extensions of SamlResponse that need to expose other information that
the plain java-saml library does not (like the response issue instant,
or any custom contents of the AuthnContext in the assertion auth
statement). Having these two methods private forces the extender to
reimplement them from scratch, probably by copy-and-paste, which is
clearly sub-optimal.

A concrete example: the Italian SPID authentication system expects the "authentication level" to be specified within the `AuthnContextClassRef` element. Also, it recommends to track the response issue instant, so when using java-saml to implement a SPID SP, these two pieces of information should be extracted from the response.

Please note I also removed a clear repetition in the `query` method implementation, by delegating to `getSAMLResponseDocument()` to retrieve the non-encrypted `Document` instance.