### PR TITLE
Add Auth.getLastMessageIssueInstant and Auth.getLastRequestIssueInstant

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -261,4 +261,13 @@ public class AuthnRequest {
 	{
 		return id;
 	}
+	
+	/**
+	 * Returns the issue instant of this message.
+	 * 
+	 * @return a new {@link Calendar} instance carrying the issue instant of this message
+	 */
+	public Calendar getIssueInstant() {
+		return issueInstant == null? null: (Calendar) issueInstant.clone();
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1238,5 +1239,31 @@ public class SamlResponse {
 		if (settings.isStrict() && !spNameQualifier.equals(settings.getSpEntityId())) {
 			throw new ValidationError("The SPNameQualifier value mismatch the SP entityID value.", ValidationError.SP_NAME_QUALIFIER_NAME_MISMATCH);
 		}
+	}
+
+	/**
+	 * Returns the issue instant of this message.
+	 *
+	 * @return a new {@link Calendar} instance carrying the issue instant of this message
+	 * @throws ValidationError
+	 *             if the found IssueInstant attribute is not in the expected
+	 *             UTC form of ISO-8601 format
+	 */
+	public Calendar getResponseIssueInstant() throws ValidationError {
+		final Element rootElement = getSAMLResponseDocument()
+				.getDocumentElement();
+		final String issueInstantString = rootElement.hasAttribute(
+				"IssueInstant")? rootElement.getAttribute("IssueInstant"): null;
+		if(issueInstantString == null)
+			return null;
+		final Calendar result = Calendar.getInstance();
+		try {
+			result.setTimeInMillis(Util.parseDateTime(issueInstantString).getMillis());
+		} catch (final IllegalArgumentException e) {
+			throw new ValidationError(
+					"The Response IssueInstant attribute is not in the expected UTC form of ISO-8601 format",
+					ValidationError.INVALID_ISSUE_INSTANT_FORMAT);
+		}
+		return result;
 	}
 }

--- a/core/src/main/java/com/onelogin/saml2/exception/ValidationError.java
+++ b/core/src/main/java/com/onelogin/saml2/exception/ValidationError.java
@@ -53,6 +53,7 @@ public class ValidationError extends SAMLException {
 	public static final int NOT_SUPPORTED = 46;
 	public static final int KEY_ALGORITHM_ERROR = 47;
 	public static final int MISSING_ENCRYPTED_ELEMENT = 48;
+	public static final int INVALID_ISSUE_INSTANT_FORMAT = 49;
 
 	private int errorCode;
 

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -144,7 +144,9 @@ public class LogoutRequest {
 			logoutRequestString = substitutor.replace(getLogoutRequestTemplate());
 		} else {
 			logoutRequestString = Util.base64decodedInflated(samlLogoutRequest);
-			id = getId(logoutRequestString);
+			Document doc = Util.loadXML(logoutRequestString);
+			id = getId(doc);
+			issueInstant = getIssueInstant(doc);
 		}
 	}
 
@@ -487,14 +489,14 @@ public class LogoutRequest {
 		}
 	}
 
-    /**
-     * Returns the ID of the Logout Request Document.
-     *
+      /**
+       * Returns the ID of the Logout Request Document.
+       *
 	 * @param samlLogoutRequestDocument
 	 * 				A DOMDocument object loaded from the SAML Logout Request.
 	 *
-     * @return the ID of the Logout Request.
-     */
+       * @return the ID of the Logout Request.
+       */
 	public static String getId(Document samlLogoutRequestDocument) {
 		String id = null;
 		try {
@@ -505,18 +507,54 @@ public class LogoutRequest {
 		return id;
 	}
 
-    /**
-     * Returns the ID of the Logout Request String.
-     *
-	 * @param samlLogoutRequestString
-	 * 				A Logout Request string.
-	 *
-     * @return the ID of the Logout Request.
-     *
-     */
+      /**
+       * Returns the issue instant of the Logout Request Document.
+       *
+       * @param samlLogoutRequestDocument
+       * 				A DOMDocument object loaded from the SAML Logout Request.
+       *
+       * @return the issue instant of the Logout Request.
+       */
+	public static Calendar getIssueInstant(Document samlLogoutRequestDocument) {
+		Calendar issueInstant = null;
+		try {
+			Element rootElement = samlLogoutRequestDocument.getDocumentElement();
+			rootElement.normalize();
+			String issueInstantString = rootElement.hasAttribute(
+					"IssueInstant")? rootElement.getAttribute("IssueInstant"): null;
+			if(issueInstantString == null)
+				return null;
+			issueInstant = Calendar.getInstance();
+			issueInstant.setTimeInMillis(Util.parseDateTime(issueInstantString).getMillis());
+		} catch (Exception e) {}
+		return issueInstant;
+	}
+
+      /**
+       * Returns the ID of the Logout Request String.
+       *
+       * @param samlLogoutRequestString
+       * 				A Logout Request string.
+       *
+       * @return the ID of the Logout Request.
+       *
+       */
 	public static String getId(String samlLogoutRequestString) {
 		Document doc = Util.loadXML(samlLogoutRequestString);
 		return getId(doc);
+	}
+	
+      /**
+       * Returns the issue instant of the Logout Request Document.
+       *
+       * @param samlLogoutRequestDocument
+       * 				A DOMDocument object loaded from the SAML Logout Request.
+       *
+       * @return the issue instant of the Logout Request.
+       */
+	public static Calendar getIssueInstant(String samlLogoutRequestString) {
+		Document doc = Util.loadXML(samlLogoutRequestString);
+		return getIssueInstant(doc);
 	}
 
 	/**
@@ -765,5 +803,14 @@ public class LogoutRequest {
 	public String getId()
 	{
 		return id;
+	}
+
+	/**
+	 * Returns the issue instant of this message.
+	 * 
+	 * @return a new {@link Calendar} instance carrying the issue instant of this message
+	 */
+	public Calendar getIssueInstant() {
+		return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -475,4 +475,33 @@ public class LogoutResponse {
 	public Exception getValidationException() {
 		return validationException;
 	}
+	
+	/**
+	 * Returns the issue instant of this message.
+	 *
+	 * @return a new {@link Calendar} instance carrying the issue instant of this message
+	 * @throws ValidationError
+	 *             if this logout response was received and parsed and the found IssueInstant 
+	 *             attribute is not in the expected UTC form of ISO-8601 format
+	 */
+	public Calendar getIssueInstant() throws ValidationError {
+		if(logoutResponseDocument != null) {
+			final Element rootElement = logoutResponseDocument
+					.getDocumentElement();
+			final String issueInstantString = rootElement.hasAttribute(
+					"IssueInstant")? rootElement.getAttribute("IssueInstant"): null;
+			if(issueInstantString == null)
+				return null;
+			final Calendar result = Calendar.getInstance();
+			try {
+				result.setTimeInMillis(Util.parseDateTime(issueInstantString).getMillis());
+			} catch (final IllegalArgumentException e) {
+				throw new ValidationError(
+						"The Response IssueInstant attribute is not in the expected UTC form of ISO-8601 format",
+						ValidationError.INVALID_ISSUE_INSTANT_FORMAT);
+			}
+			return result;
+		} else
+			return issueInstant == null? null: (Calendar) issueInstant.clone();
+	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -4,11 +4,15 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.onelogin.saml2.authn.AuthnRequest;
@@ -325,6 +329,32 @@ public class AuthnRequestTest {
 
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, containsString("ID=\"" + authnRequest.getId() + "\""));
+	}
+
+	/**
+	 * Tests the getId method of AuthnRequest
+	 *
+	 * @throws Exception
+	 * 
+	 * @see com.onelogin.saml2.authn.AuthnRequest.getId
+	 */
+	@Test
+	public void testGetIssueInstant() throws Exception
+	{
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+
+		final long start = System.currentTimeMillis();
+		AuthnRequest authnRequest = new AuthnRequest(settings);
+		final long end = System.currentTimeMillis();
+		final String authnRequestStr = Util.base64decodedInflated(authnRequest.getEncodedAuthnRequest());
+
+		final Calendar issueInstant = authnRequest.getIssueInstant();
+		assertNotNull(issueInstant);
+		final long millis = issueInstant.getTimeInMillis();
+		assertTrue(millis >= start && millis <= end);
+		
+		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
+		assertThat(authnRequestStr, containsString("IssueInstant=\"" + Util.formatDateTime(millis) + "\""));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -29,6 +29,7 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -478,6 +479,29 @@ public class AuthnResponseTest {
 		assertTrue(samlResponse.getNameIdData().isEmpty());
 	}
 
+	/**
+	 * Tests the getIssueInstant method of SamlResponse
+	 *
+	 * @throws Exception
+	 *
+	 * @see com.onelogin.saml2.authn.SamlResponse#getResponseIssueInstant()
+	 */
+	@Test
+	public void testGetIssueInstant() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+		String samlResponseEncoded = Util.getFileAsString("data/responses/response1.xml.base64");
+		SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+		assertEquals("2010-11-18T21:57:37Z", Util.formatDateTime(samlResponse.getResponseIssueInstant().getTimeInMillis()));
+
+		samlResponseEncoded = Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64");
+		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+		assertEquals("2014-03-09T12:23:37Z", Util.formatDateTime(samlResponse.getResponseIssueInstant().getTimeInMillis()));
+
+		samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
+		samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+		assertEquals("2014-03-29T12:01:57Z", Util.formatDateTime(samlResponse.getResponseIssueInstant().getTimeInMillis()));
+	}
+	
 	/**
 	 * Tests the decryptAssertion method of SamlResponse
 	 * Case: EncryptedAssertion with an encryptedData element with a KeyInfo

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -7,11 +7,13 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.onelogin.saml2.exception.ValidationError;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Calendar;
 
 import javax.xml.xpath.XPathExpressionException;
 
@@ -244,6 +246,49 @@ public class LogoutResponseTest {
 		httpRequest = newHttpRequest(requestURL, samlResponseEncoded);
 		logoutResponse = new LogoutResponse(settings, httpRequest);
 		assertNull(logoutResponse.getIssuer());
+	}
+
+	/**
+	 * Tests the getIssueInstant method of LogoutResponse
+	 * 
+	 * @throws IOException 
+	 * @throws Error 
+	 * @throws ValidationError 
+	 *
+	 * @see com.onelogin.saml2.logout.LogoutResponse#getIssueInstant()
+	 */
+	@Test
+	public void testGetIssueInstant() throws IOException, Error, ValidationError {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response_deflated.xml.base64");
+		final String requestURL = "/";
+		HttpRequest httpRequest = newHttpRequest(requestURL, samlResponseEncoded);
+		LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);
+		assertEquals("2013-12-10T04:39:31Z", Util.formatDateTime(logoutResponse.getIssueInstant().getTimeInMillis()));
+	}
+
+	/**
+	 * Tests the getIssueInstant method of LogoutResponse
+	 * <p>
+	 * Case: LogoutResponse message built by the caller.
+	 * 
+	 * @throws IOException 
+	 * @throws Error 
+	 * @throws ValidationError 
+	 *
+	 * @see com.onelogin.saml2.logout.LogoutResponse#getIssueInstant()
+	 */
+	@Test
+	public void testGetIssueInstantBuiltMessage() throws IOException, Error, ValidationError {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		long start = System.currentTimeMillis();
+		LogoutResponse logoutResponse = new LogoutResponse(settings, null);
+		logoutResponse.build();
+		long end = System.currentTimeMillis();
+		Calendar issueInstant = logoutResponse.getIssueInstant();
+		assertNotNull(issueInstant);
+		long millis = issueInstant.getTimeInMillis();
+		assertTrue(millis >= start && millis <= end);
 	}
 
 	/**

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -6,6 +6,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.SignatureException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -102,6 +103,11 @@ public class Auth {
 	 * The ID of the last message processed
 	 */
 	private String lastMessageId;
+	
+	/**
+	 * The issue instant of the last message processed
+	 */
+	private Calendar lastMessageIssueInstant;
 
 	/**
 	 * The ID of the last assertion processed
@@ -142,6 +148,11 @@ public class Auth {
 	 * The id of the last request (Authn or Logout) generated
 	 */
 	private String lastRequestId;
+
+	/**
+	 * The issue instant of the last request (Authn or Logout) generated
+	 */
+	private Calendar lastRequestIssueInstant;
 
 	/**
 	 * The most recently-constructed/processed XML SAML request
@@ -392,6 +403,7 @@ public class Auth {
 
 		String ssoUrl = getSSOurl();
 		lastRequestId = authnRequest.getId();
+		lastRequestIssueInstant = authnRequest.getIssueInstant();
 		lastRequest = authnRequest.getAuthnRequestXml();
 
 		if (!stay) {
@@ -565,6 +577,7 @@ public class Auth {
 
 		String sloUrl = getSLOurl();
 		lastRequestId = logoutRequest.getId();
+		lastRequestIssueInstant = logoutRequest.getIssueInstant();
 		lastRequest = logoutRequest.getLogoutRequestXml();
 
 		if (!stay) {
@@ -814,6 +827,7 @@ public class Auth {
 				sessionIndex = samlResponse.getSessionIndex();
 				sessionExpiration = samlResponse.getSessionNotOnOrAfter();
 				lastMessageId = samlResponse.getId();
+				lastMessageIssueInstant = samlResponse.getResponseIssueInstant();
 				lastAssertionId = samlResponse.getAssertionId();
 				lastAssertionNotOnOrAfter = samlResponse.getAssertionNotOnOrAfter();
 				LOGGER.debug("processResponse success --> " + samlResponseParameter);
@@ -894,6 +908,7 @@ public class Auth {
 					}
 				} else {
 					lastMessageId = logoutResponse.getId();
+					lastMessageIssueInstant = logoutResponse.getIssueInstant();
 					LOGGER.debug("processSLO success --> " + samlResponseParameter);
 					if (!keepLocalSession) {
 						request.getSession().invalidate();
@@ -913,6 +928,7 @@ public class Auth {
 				return null;
 			} else {
 				lastMessageId = logoutRequest.getId();
+				lastMessageIssueInstant = logoutRequest.getIssueInstant();
 				LOGGER.debug("processSLO success --> " + samlRequestParameter);
 				if (!keepLocalSession) {
 					request.getSession().invalidate();
@@ -1059,6 +1075,15 @@ public class Auth {
 	public String getLastMessageId() {
 		return lastMessageId;
 	}
+	
+	/**
+	 * Returns the issue instant of the last message processed.
+	 * 
+	 * @return The issue instant of the last message processed
+	 */
+	public Calendar getLastMessageIssueInstant() {
+		return lastMessageIssueInstant;
+	}
 
 	/**
 	 * @return The ID of the last assertion processed
@@ -1102,6 +1127,16 @@ public class Auth {
 	 */
 	public String getLastRequestId() {
 		return lastRequestId;
+	}
+	
+	/**
+	 * Returns the issue instant of the last request generated (AuthnRequest or LogoutRequest).
+	 * 
+	 * @return the issue instant of the last request generated (AuthnRequest or LogoutRequest),
+	 *         <code>null</code> if none
+	 */
+	public Calendar getLastRequestIssueInstant() {
+		return lastRequestIssueInstant;
 	}
 
 	/**

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -2088,6 +2088,9 @@ public class AuthTest {
 		String targetSSOURL = auth.login(null, false, false, false, true);
 		String authNRequestXML = auth.getLastRequestXML();
 		assertThat(targetSSOURL, containsString(Util.urlEncoder(Util.deflatedBase64encoded(authNRequestXML))));
+		
+		assertThat(authNRequestXML, containsString("ID=\"" + auth.getLastRequestId() + "\""));
+		assertThat(authNRequestXML, containsString("IssueInstant=\"" + Util.formatDateTime(auth.getLastRequestIssueInstant().getTimeInMillis()) + "\""));
 	}
 
 	/**
@@ -2111,6 +2114,9 @@ public class AuthTest {
 		String targetSLOURL = auth.logout(null, null, null, true);
 		String logoutRequestXML = auth.getLastRequestXML();
 		assertThat(targetSLOURL, containsString(Util.urlEncoder(Util.deflatedBase64encoded(logoutRequestXML))));
+
+		assertThat(logoutRequestXML, containsString("ID=\"" + auth.getLastRequestId() + "\""));
+		assertThat(logoutRequestXML, containsString("IssueInstant=\"" + Util.formatDateTime(auth.getLastRequestIssueInstant().getTimeInMillis()) + "\""));
 	}
 
 	/**


### PR DESCRIPTION
Each message (AuthnRequest, SamlResponse, LogoutRequest and
LogoutResponse) have been enhanced to expose their issue instant. This
is useful for logging purposes (i.e.: you want to track each request
you generate and each response you receive, along with their issue
instant), which is also required when implementing a SPID Service
Provider (SPID is a SAML 2.0-based federated system used by the Italian
government).
I also tried to implement some tests for Auth, but I did not succeed for
the "received message" scenario, because, to be coherent with the "last
message id" case, the "last message issue instant" information is set
on the Auth instance only if the message processing succeeds (i.e.: the
processed message is valid). The test data used here seems to fail
validation because of time expiration (which is reasonable), so testing
these methods in the "receive" scenario would require to write test
messages with valid timestamps dynamically.