### PR TITLE
Allow for extension classes to post-process generated XML

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -288,13 +288,4 @@ public class AuthnRequest {
 	public Calendar getIssueInstant() {
 		return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
-
-	/**
-	 * Returns the SAML settings specified at construction time.
-	 * 
-	 * @return the SAML settings
-	 */
-	protected Saml2Settings getSettings() {
-		return settings;
-	}
 }

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -129,14 +129,14 @@ public class AuthnRequest {
 	 * this class have already been initialised. Its default implementation simply
 	 * returns the input XML as-is, with no change.
 	 * 
-	 * @param authRequestXml
+	 * @param authnRequestXml
 	 *              the XML produced for this AuthnRequest by the standard
 	 *              implementation provided by {@link AuthnRequest}
 	 * @return the post-processed XML for this AuthnRequest, which will then be
 	 *         returned by any call to {@link #getAuthnRequestXml()}
 	 */
-	protected String postProcessXml(final String authRequestXml) {
-		return authRequestXml;
+	protected String postProcessXml(final String authnRequestXml) {
+		return authnRequestXml;
 	}
 	
 	/**

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -101,7 +101,7 @@ public class AuthnRequest {
 		this.nameIdValueReq = nameIdValueReq;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings);
-		authnRequestString = substitutor.replace(getAuthnRequestTemplate());
+		authnRequestString = postProcessXml(substitutor.replace(getAuthnRequestTemplate()));
 		LOGGER.debug("AuthNRequest --> " + authnRequestString);
 	}
 
@@ -121,6 +121,24 @@ public class AuthnRequest {
 		this(settings, forceAuthn, isPassive, setNameIdPolicy, null);
 	}
 
+	/**
+	 * Allows for an extension class to post-process the AuthnRequest XML generated
+	 * for this request, in order to customize the result.
+	 * <p>
+	 * This method is invoked at construction time, after all the other fields of
+	 * this class have already been initialised. Its default implementation simply
+	 * returns the input XML as-is, with no change.
+	 * 
+	 * @param authRequestXml
+	 *              the XML produced for this AuthnRequest by the standard
+	 *              implementation provided by {@link AuthnRequest}
+	 * @return the post-processed XML for this AuthnRequest, which will then be
+	 *         returned by any call to {@link #getAuthnRequestXml()}
+	 */
+	protected String postProcessXml(final String authRequestXml) {
+		return authRequestXml;
+	}
+	
 	/**
 	 * @return the base64 encoded unsigned AuthnRequest (deflated or not)
 	 *

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -11,8 +11,8 @@ import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.model.Organization;
+import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
 
@@ -101,7 +101,7 @@ public class AuthnRequest {
 		this.nameIdValueReq = nameIdValueReq;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings);
-		authnRequestString = postProcessXml(substitutor.replace(getAuthnRequestTemplate()));
+		authnRequestString = postProcessXml(substitutor.replace(getAuthnRequestTemplate()), settings);
 		LOGGER.debug("AuthNRequest --> " + authnRequestString);
 	}
 
@@ -132,10 +132,12 @@ public class AuthnRequest {
 	 * @param authnRequestXml
 	 *              the XML produced for this AuthnRequest by the standard
 	 *              implementation provided by {@link AuthnRequest}
+	 * @param settings
+	 *              the settings
 	 * @return the post-processed XML for this AuthnRequest, which will then be
 	 *         returned by any call to {@link #getAuthnRequestXml()}
 	 */
-	protected String postProcessXml(final String authnRequestXml) {
+	protected String postProcessXml(final String authnRequestXml, final Saml2Settings settings) {
 		return authnRequestXml;
 	}
 	

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -288,4 +288,13 @@ public class AuthnRequest {
 	public Calendar getIssueInstant() {
 		return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
+
+	/**
+	 * Returns the SAML settings specified at construction time.
+	 * 
+	 * @return the SAML settings
+	 */
+	protected Saml2Settings getSettings() {
+		return settings;
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -41,13 +41,13 @@ import com.onelogin.saml2.util.Util;
  */
 public class SamlResponse {
 	/**
-     * Private property to construct a logger for this class.
-     */
+       * Private property to construct a logger for this class.
+       */
 	private static final Logger LOGGER = LoggerFactory.getLogger(SamlResponse.class);
 
 	/**
-     * Settings data.
-     */
+       * Settings data.
+       */
 	private final Saml2Settings settings;
 
 	/**
@@ -1321,5 +1321,14 @@ public class SamlResponse {
 					ValidationError.INVALID_ISSUE_INSTANT_FORMAT);
 		}
 		return result;
+	}
+
+	/**
+	 * Returns the SAML settings specified at construction time.
+	 * 
+	 * @return the SAML settings
+	 */
+	protected Saml2Settings getSettings() {
+		return settings;
 	}
 }

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -41,13 +41,13 @@ import com.onelogin.saml2.util.Util;
  */
 public class SamlResponse {
 	/**
-       * Private property to construct a logger for this class.
-       */
+     * Private property to construct a logger for this class.
+     */
 	private static final Logger LOGGER = LoggerFactory.getLogger(SamlResponse.class);
 
 	/**
-       * Settings data.
-       */
+     * Settings data.
+     */
 	private final Saml2Settings settings;
 
 	/**
@@ -1321,14 +1321,5 @@ public class SamlResponse {
 					ValidationError.INVALID_ISSUE_INSTANT_FORMAT);
 		}
 		return result;
-	}
-
-	/**
-	 * Returns the SAML settings specified at construction time.
-	 * 
-	 * @return the SAML settings
-	 */
-	protected Saml2Settings getSettings() {
-		return settings;
 	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -829,13 +829,4 @@ public class LogoutRequest {
 	public Calendar getIssueInstant() {
 		return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
-	
-	/**
-	 * Returns the SAML settings specified at construction time.
-	 * 
-	 * @return the SAML settings
-	 */
-	protected Saml2Settings getSettings() {
-		return settings;
-	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -139,7 +139,7 @@ public class LogoutRequest {
 			this.sessionIndex = sessionIndex;
 	
 			StrSubstitutor substitutor = generateSubstitutor(settings);
-			logoutRequestString = postProcessXml(substitutor.replace(getLogoutRequestTemplate()));
+			logoutRequestString = postProcessXml(substitutor.replace(getLogoutRequestTemplate()), settings);
 		} else {
 			logoutRequestString = Util.base64decodedInflated(samlLogoutRequest);
 			Document doc = Util.loadXML(logoutRequestString);
@@ -237,10 +237,12 @@ public class LogoutRequest {
 	 * @param logoutRequestXml
 	 *              the XML produced for this LogoutRequest by the standard
 	 *              implementation provided by {@link LogoutRequest}
+	 * @param settings
+	 *              the settings
 	 * @return the post-processed XML for this LogoutRequest, which will then be
 	 *         returned by any call to {@link #getLogoutRequestXml()}
 	 */
-	protected String postProcessXml(final String logoutRequestXml) {
+	protected String postProcessXml(final String logoutRequestXml, final Saml2Settings settings) {
 		return logoutRequestXml;
 	}
 

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -139,7 +139,7 @@ public class LogoutRequest {
 			this.sessionIndex = sessionIndex;
 	
 			StrSubstitutor substitutor = generateSubstitutor(settings);
-			logoutRequestString = substitutor.replace(getLogoutRequestTemplate());
+			logoutRequestString = postProcessXml(substitutor.replace(getLogoutRequestTemplate()));
 		} else {
 			logoutRequestString = Util.base64decodedInflated(samlLogoutRequest);
 			Document doc = Util.loadXML(logoutRequestString);
@@ -222,6 +222,26 @@ public class LogoutRequest {
 	 */
 	public LogoutRequest(Saml2Settings settings, HttpRequest request) {
 		this(settings, request, null, null);
+	}
+
+	/**
+	 * Allows for an extension class to post-process the LogoutRequest XML generated
+	 * for this request, in order to customize the result.
+	 * <p>
+	 * This method is invoked at construction time when no existing LogoutRequest
+	 * message is found in the HTTP request (and hence in the logout request sending
+	 * scenario only), after all the other fields of this class have already been
+	 * initialised. Its default implementation simply returns the input XML as-is,
+	 * with no change.
+	 * 
+	 * @param logoutRequestXml
+	 *              the XML produced for this LogoutRequest by the standard
+	 *              implementation provided by {@link LogoutRequest}
+	 * @return the post-processed XML for this LogoutRequest, which will then be
+	 *         returned by any call to {@link #getLogoutRequestXml()}
+	 */
+	protected String postProcessXml(final String logoutRequestXml) {
+		return logoutRequestXml;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -829,4 +829,13 @@ public class LogoutRequest {
 	public Calendar getIssueInstant() {
 		return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
+	
+	/**
+	 * Returns the SAML settings specified at construction time.
+	 * 
+	 * @return the SAML settings
+	 */
+	protected Saml2Settings getSettings() {
+		return settings;
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -534,13 +534,4 @@ public class LogoutResponse {
 		} else
 			return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
-
-	/**
-	 * Returns the SAML settings specified at construction time.
-	 * 
-	 * @return the SAML settings
-	 */
-	protected Saml2Settings getSettings() {
-		return settings;
-	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -364,7 +364,7 @@ public class LogoutResponse {
 		this.inResponseTo = inResponseTo;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings, statusCode);
-		this.logoutResponseString = postProcessXml(substitutor.replace(getLogoutResponseTemplate()));
+		this.logoutResponseString = postProcessXml(substitutor.replace(getLogoutResponseTemplate()), settings);
 	}
 
     /**
@@ -396,10 +396,12 @@ public class LogoutResponse {
 	 * @param logoutResponseXml
 	 *              the XML produced for this LogoutResponse by the standard
 	 *              implementation provided by {@link LogoutResponse}
+	 * @param settings
+	 *              the settings
 	 * @return the post-processed XML for this LogoutResponse, which will then be
 	 *         returned by any call to {@link #getLogoutResponseXml()}
 	 */
-	protected String postProcessXml(final String logoutResponseXml) {
+	protected String postProcessXml(final String logoutResponseXml, final Saml2Settings settings) {
 		return logoutResponseXml;
 	}
 	

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -534,4 +534,13 @@ public class LogoutResponse {
 		} else
 			return issueInstant == null? null: (Calendar) issueInstant.clone();
 	}
+
+	/**
+	 * Returns the SAML settings specified at construction time.
+	 * 
+	 * @return the SAML settings
+	 */
+	protected Saml2Settings getSettings() {
+		return settings;
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutResponse.java
@@ -364,7 +364,7 @@ public class LogoutResponse {
 		this.inResponseTo = inResponseTo;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings, statusCode);
-		this.logoutResponseString = substitutor.replace(getLogoutResponseTemplate());
+		this.logoutResponseString = postProcessXml(substitutor.replace(getLogoutResponseTemplate()));
 	}
 
     /**
@@ -385,6 +385,24 @@ public class LogoutResponse {
 		build(null);
 	}	
 
+	/**
+	 * Allows for an extension class to post-process the LogoutResponse XML
+	 * generated for this response, in order to customize the result.
+	 * <p>
+	 * This method is invoked by {@link #build(String, String)} (and all of its
+	 * overloadings) and hence only in the logout response sending scenario. Its
+	 * default implementation simply returns the input XML as-is, with no change.
+	 * 
+	 * @param logoutResponseXml
+	 *              the XML produced for this LogoutResponse by the standard
+	 *              implementation provided by {@link LogoutResponse}
+	 * @return the post-processed XML for this LogoutResponse, which will then be
+	 *         returned by any call to {@link #getLogoutResponseXml()}
+	 */
+	protected String postProcessXml(final String logoutResponseXml) {
+		return logoutResponseXml;
+	}
+	
 	/**
 	 * Substitutes LogoutResponse variables within a string by values.
 	 *

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -63,6 +63,11 @@ public class Metadata {
 	private final Integer cacheDuration;
 
 	/**
+       * Settings data.
+       */
+	private final Saml2Settings settings;
+
+	/**
 	 * Constructs the Metadata object.
 	 *
 	 * @param settings                  Saml2Settings object. Setting data
@@ -72,6 +77,7 @@ public class Metadata {
 	 * @throws CertificateEncodingException
 	 */
 	public Metadata(Saml2Settings settings, Calendar validUntilTime, Integer cacheDuration, AttributeConsumingService attributeConsumingService) throws CertificateEncodingException {
+		this.settings = settings;
 		this.validUntilTime = validUntilTime;
 		this.attributeConsumingService = attributeConsumingService;
 		this.cacheDuration = cacheDuration;
@@ -102,7 +108,7 @@ public class Metadata {
 	 * @throws CertificateEncodingException
 	 */
 	public Metadata(Saml2Settings settings) throws CertificateEncodingException {
-
+		this.settings = settings;
 		this.validUntilTime = Calendar.getInstance();
 		this.validUntilTime.add(Calendar.DAY_OF_YEAR, N_DAYS_VALID_UNTIL);
 
@@ -406,5 +412,14 @@ public class Metadata {
 		String signedMetadata = Util.addSign(metadataDoc, key, cert, signAlgorithm, digestAlgorithm);
 		LOGGER.debug("Signed metadata --> " + signedMetadata);
 		return signedMetadata;
+	}
+	
+	/**
+	 * Returns the SAML settings specified at construction time.
+	 * 
+	 * @return the SAML settings
+	 */
+	protected Saml2Settings getSettings() {
+		return settings;
 	}
 }

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -109,10 +109,28 @@ public class Metadata {
 		this.cacheDuration = SECONDS_CACHED;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings);
-		String unsignedMetadataString = substitutor.replace(getMetadataTemplate());
+		String unsignedMetadataString = postProcessXml(substitutor.replace(getMetadataTemplate()));
 
 		LOGGER.debug("metadata --> " + unsignedMetadataString);
 		metadataString = unsignedMetadataString;
+	}
+	
+	/**
+	 * Allows for an extension class to post-process the SAML metadata XML generated
+	 * for this metadata instance, in order to customize the result.
+	 * <p>
+	 * This method is invoked at construction time, after all the other fields of
+	 * this class have already been initialised. Its default implementation simply
+	 * returns the input XML as-is, with no change.
+	 * 
+	 * @param metadataXml
+	 *              the XML produced for this metadata instance by the standard
+	 *              implementation provided by {@link Metadata}
+	 * @return the post-processed XML for this metadata instance, which will then be
+	 *         returned by any call to {@link #getMetadataString()}
+	 */
+	protected String postProcessXml(final String metadataXml) {
+		return metadataXml;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -83,7 +83,7 @@ public class Metadata {
 		this.cacheDuration = cacheDuration;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings);
-		String unsignedMetadataString = substitutor.replace(getMetadataTemplate());
+		String unsignedMetadataString = postProcessXml(substitutor.replace(getMetadataTemplate()));
 
 		LOGGER.debug("metadata --> " + unsignedMetadataString);
 		metadataString = unsignedMetadataString;

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -77,7 +77,7 @@ public class Metadata {
 		this.cacheDuration = cacheDuration;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings);
-		String unsignedMetadataString = postProcessXml(substitutor.replace(getMetadataTemplate()));
+		String unsignedMetadataString = postProcessXml(substitutor.replace(getMetadataTemplate()), settings);
 
 		LOGGER.debug("metadata --> " + unsignedMetadataString);
 		metadataString = unsignedMetadataString;
@@ -109,7 +109,7 @@ public class Metadata {
 		this.cacheDuration = SECONDS_CACHED;
 
 		StrSubstitutor substitutor = generateSubstitutor(settings);
-		String unsignedMetadataString = postProcessXml(substitutor.replace(getMetadataTemplate()));
+		String unsignedMetadataString = postProcessXml(substitutor.replace(getMetadataTemplate()), settings);
 
 		LOGGER.debug("metadata --> " + unsignedMetadataString);
 		metadataString = unsignedMetadataString;
@@ -126,10 +126,12 @@ public class Metadata {
 	 * @param metadataXml
 	 *              the XML produced for this metadata instance by the standard
 	 *              implementation provided by {@link Metadata}
+	 * @param settings
+	 *              the settings
 	 * @return the post-processed XML for this metadata instance, which will then be
 	 *         returned by any call to {@link #getMetadataString()}
 	 */
-	protected String postProcessXml(final String metadataXml) {
+	protected String postProcessXml(final String metadataXml, final Saml2Settings settings) {
 		return metadataXml;
 	}
 

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -63,11 +63,6 @@ public class Metadata {
 	private final Integer cacheDuration;
 
 	/**
-       * Settings data.
-       */
-	private final Saml2Settings settings;
-
-	/**
 	 * Constructs the Metadata object.
 	 *
 	 * @param settings                  Saml2Settings object. Setting data
@@ -77,7 +72,6 @@ public class Metadata {
 	 * @throws CertificateEncodingException
 	 */
 	public Metadata(Saml2Settings settings, Calendar validUntilTime, Integer cacheDuration, AttributeConsumingService attributeConsumingService) throws CertificateEncodingException {
-		this.settings = settings;
 		this.validUntilTime = validUntilTime;
 		this.attributeConsumingService = attributeConsumingService;
 		this.cacheDuration = cacheDuration;
@@ -108,7 +102,7 @@ public class Metadata {
 	 * @throws CertificateEncodingException
 	 */
 	public Metadata(Saml2Settings settings) throws CertificateEncodingException {
-		this.settings = settings;
+
 		this.validUntilTime = Calendar.getInstance();
 		this.validUntilTime.add(Calendar.DAY_OF_YEAR, N_DAYS_VALID_UNTIL);
 
@@ -412,14 +406,5 @@ public class Metadata {
 		String signedMetadata = Util.addSign(metadataDoc, key, cert, signAlgorithm, digestAlgorithm);
 		LOGGER.debug("Signed metadata --> " + signedMetadata);
 		return signedMetadata;
-	}
-	
-	/**
-	 * Returns the SAML settings specified at construction time.
-	 * 
-	 * @return the SAML settings
-	 */
-	protected Saml2Settings getSettings() {
-		return settings;
 	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -395,7 +396,9 @@ public class AuthnRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		AuthnRequest authnRequest = new AuthnRequest(settings) {
 			@Override
-			protected String postProcessXml(String authRequestXml) {
+			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
+				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+				assertSame(settings, sett);
 				return "changed";
 			}
 		};

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -382,4 +382,23 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("Destination=\"http://idp.example.com/simplesaml/saml2/idp/SSOService.php\"")));
 	}
+	
+	/**
+	 * Tests the postProcessXml method of AuthnRequest
+	 *
+	 * @throws Exception
+	 * 
+	 * @see com.onelogin.saml2.authn.AuthnRequest#postProcessXml
+	 */
+	@Test
+	public void testPostProcessXml() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		AuthnRequest authnRequest = new AuthnRequest(settings) {
+			@Override
+			protected String postProcessXml(String authRequestXml) {
+				return "changed";
+			}
+		};
+		assertEquals("changed", authnRequest.getAuthnRequestXml());
+	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -945,7 +946,9 @@ public class LogoutRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		LogoutRequest logoutRequest = new LogoutRequest(settings) {
 			@Override
-			protected String postProcessXml(String authRequestXml) {
+			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
+				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+				assertSame(settings, sett);
 				return "changed";
 			}
 		};

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -932,4 +932,23 @@ public class LogoutRequestTest {
 	private static HttpRequest newHttpRequest(String requestURL, String samlRequestEncoded) {
 		return new HttpRequest(requestURL, (String)null).addParameter("SAMLRequest", samlRequestEncoded);
 	}
+
+	/**
+	 * Tests the postProcessXml method of LogoutRequest
+	 *
+	 * @throws Exception
+	 * 
+	 * @see com.onelogin.saml2.logout.LogoutRequest#postProcessXml
+	 */
+	@Test
+	public void testPostProcessXml() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		LogoutRequest logoutRequest = new LogoutRequest(settings) {
+			@Override
+			protected String postProcessXml(String authRequestXml) {
+				return "changed";
+			}
+		};
+		assertEquals("changed", logoutRequest.getLogoutRequestXml());
+	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -704,7 +705,9 @@ public class LogoutResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		LogoutResponse logoutResponse = new LogoutResponse(settings, null) {
 			@Override
-			protected String postProcessXml(String authRequestXml) {
+			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
+				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+				assertSame(settings, sett);
 				return "changed";
 			}
 		};

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -691,4 +691,24 @@ public class LogoutResponseTest {
 	private static HttpRequest newHttpRequest(String requestURL, String samlResponseEncoded) {
 		return new HttpRequest(requestURL, (String)null).addParameter("SAMLResponse", samlResponseEncoded);
 	}
+
+	/**
+	 * Tests the postProcessXml method of LogoutResponse
+	 *
+	 * @throws Exception
+	 * 
+	 * @see com.onelogin.saml2.logout.LogoutResponse#postProcessXml
+	 */
+	@Test
+	public void testPostProcessXml() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		LogoutResponse logoutResponse = new LogoutResponse(settings, null) {
+			@Override
+			protected String postProcessXml(String authRequestXml) {
+				return "changed";
+			}
+		};
+		logoutResponse.build();
+		assertEquals("changed", logoutResponse.getLogoutResponseXml());
+	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
@@ -520,4 +520,23 @@ public class MetadataTest {
 		assertNull("should not set cache duration attribute", cacheDurationNode);
 
 	}
+	
+	/**
+	 * Tests the postProcessXml method of Metadata
+	 *
+	 * @throws Exception
+	 * 
+	 * @see com.onelogin.saml2.settings.Metadata#postProcessXml
+	 */
+	@Test
+	public void testPostProcessXml() throws Exception {
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		Metadata metadata = new Metadata(settings) {
+			@Override
+			protected String postProcessXml(String authRequestXml) {
+				return "changed";
+			}
+		};
+		assertEquals("changed", metadata.getMetadataString());
+	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
-
+import static org.junit.Assert.assertSame;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -533,7 +533,9 @@ public class MetadataTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Metadata metadata = new Metadata(settings) {
 			@Override
-			protected String postProcessXml(String authRequestXml) {
+			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
+				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+				assertSame(settings, sett);
 				return "changed";
 			}
 		};


### PR DESCRIPTION
This change allows for any java-saml consumer to extend the standard
classes used to generate SAML messages (AuthnRequest, LogoutRequest and
LogoutResponse), as well as the metadata, and provide their own logic to
post-process the default XML produced by java-saml. Any extension class
will then be able to transform or enrich the generated XML as required,
before the framework applies encoding, encryption or signing.

This is the implementation of the idea I was thinking of when writing https://github.com/onelogin/java-saml/issues/265#issuecomment-811866110. I think this is the most non-instrusive and not too dirty way to let java-saml be extended by consumers. Of course, this is just one step: if the consumer wants to use the `Auth` class as well, the other problem I mentioned in the above comment must be solved (please see https://github.com/onelogin/java-saml/issues/265#issuecomment-811886100 for a proposal).