### PR TITLE
Make the SamlResponse returned attribute map preserve attribute order

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -5,6 +5,7 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -572,7 +573,7 @@ public class SamlResponse {
      *
      */
 	public HashMap<String, List<String>> getAttributes() throws XPathExpressionException, ValidationError {
-		HashMap<String, List<String>> attributes = new HashMap<String, List<String>>();
+		HashMap<String, List<String>> attributes = new LinkedHashMap<String, List<String>>();
 
 		NodeList nodes = this.queryAssertion("/saml:AttributeStatement/saml:Attribute");
 

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -116,7 +116,7 @@ public class Auth {
 	/**
 	 * User attributes data.
 	 */
-	private Map<String, List<String>> attributes = new HashMap<String, List<String>>();
+	private Map<String, List<String>> attributes = new LinkedHashMap<String, List<String>>();
 
 	/**
 	 * If user is authenticated.

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -31,6 +31,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -524,7 +525,7 @@ public class AuthTest {
 		when(request.getParameterMap()).thenReturn(singletonMap("SAMLResponse", new String[]{samlResponseEncoded}));
 		Auth auth2 = new Auth(settings, request, response);
 
-		HashMap<String, List<String>> expectedAttributes = new HashMap<String, List<String>>();
+		HashMap<String, List<String>> expectedAttributes = new LinkedHashMap<String, List<String>>();
 		List<String> attrValues = new ArrayList<String>();
 		attrValues.add("smartin");
 		List<String> attrValues2 = new ArrayList<String>();
@@ -538,9 +539,9 @@ public class AuthTest {
 		attrValues5.add("Martin2");
 		expectedAttributes.put("uid", attrValues);
 		expectedAttributes.put("mail", attrValues2);
-		expectedAttributes.put("eduPersonAffiliation", attrValues3);
 		expectedAttributes.put("cn", attrValues4);
 		expectedAttributes.put("sn", attrValues5);
+		expectedAttributes.put("eduPersonAffiliation", attrValues3);
 		List<String> keys = new ArrayList<String>(expectedAttributes.keySet());
 
 		assertFalse(auth2.isAuthenticated());


### PR DESCRIPTION
The map returned by SamlResposne containing the attributes returned by
the IdP now preserves the order in which such attributes appear in the
SAML response XML. This is not strictly mandatory, but a plus.
Indeed, the test method
com.onelogin.saml2.test.AuthTest.testProcessResponse() was not
deterministic before this change: indeed, the iteration order of HashMap
is undetermined so expecting to see attribute names in a given order
could lead to a test failure. This change also fixes this and attribute
names are expected now to be seen in the order in which the
corresponding attributes appear in the test XML file.

This closes #330.