### PR TITLE
Remove useless XMLEntityException declaration in logout throws clause

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -117,10 +117,8 @@ public class LogoutRequest {
 	 *				The NameID NameQualifier that will be set in the LogoutRequest.
 	 * @param nameIdSPNameQualifier
 	 *				The SP Name Qualifier that will be set in the LogoutRequest.
-	 *
-	 * @throws XMLEntityException
 	 */
-	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex, String nameIdFormat, String nameIdNameQualifier, String nameIdSPNameQualifier) throws XMLEntityException {
+	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex, String nameIdFormat, String nameIdNameQualifier, String nameIdSPNameQualifier) {
 		this.settings = settings;
 		this.request = request;
 	
@@ -163,10 +161,8 @@ public class LogoutRequest {
 	 *              The nameIdFormat that will be set in the LogoutRequest.
 	 * @param nameIdNameQualifier
 	 *				The NameID NameQualifier will be set in the LogoutRequest.
-	 *
-	 * @throws XMLEntityException
 	 */
-	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex, String nameIdFormat, String nameIdNameQualifier) throws XMLEntityException {
+	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex, String nameIdFormat, String nameIdNameQualifier) {
 		this(settings, request, nameId, sessionIndex, nameIdFormat, nameIdNameQualifier, null);
 	}
 
@@ -183,10 +179,8 @@ public class LogoutRequest {
 	 *              The SessionIndex (taken from the SAML Response in the SSO process).
 	 * @param nameIdFormat
 	 *              The nameIdFormat that will be set in the LogoutRequest.
-	 *
-	 * @throws XMLEntityException
 	 */
-	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex, String nameIdFormat) throws XMLEntityException {
+	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex, String nameIdFormat) {
 		this(settings, request, nameId, sessionIndex, nameIdFormat, null);
 	}
 
@@ -201,10 +195,8 @@ public class LogoutRequest {
 	 *              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex
 	 *              The SessionIndex (taken from the SAML Response in the SSO process).
-	 *
-	 * @throws XMLEntityException
 	 */
-	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex) throws XMLEntityException {
+	public LogoutRequest(Saml2Settings settings, HttpRequest request, String nameId, String sessionIndex) {
 		this(settings, request, nameId, sessionIndex, null);
 	}
 
@@ -213,10 +205,8 @@ public class LogoutRequest {
 	 *
 	 * @param settings
 	 *            OneLogin_Saml2_Settings
-	 *
-	 * @throws XMLEntityException 
 	 */
-	public LogoutRequest(Saml2Settings settings) throws XMLEntityException {
+	public LogoutRequest(Saml2Settings settings) {
 		this(settings, null, null, null);
 	}
 
@@ -226,11 +216,9 @@ public class LogoutRequest {
 	 * @param settings
 	 *            OneLogin_Saml2_Settings
 	 * @param request
-     *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
-     *
-	 * @throws XMLEntityException 
+       *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
 	 */
-	public LogoutRequest(Saml2Settings settings, HttpRequest request) throws XMLEntityException {
+	public LogoutRequest(Saml2Settings settings, HttpRequest request) {
 		this(settings, request, null, null);
 	}
 

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -25,7 +25,6 @@ import com.onelogin.saml2.authn.AuthnRequest;
 import com.onelogin.saml2.authn.SamlResponse;
 import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.exception.Error;
-import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.http.HttpRequest;
 import com.onelogin.saml2.logout.LogoutRequest;
 import com.onelogin.saml2.logout.LogoutResponse;
@@ -493,12 +492,11 @@ public class Auth {
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 		Map<String, String> parameters = new HashMap<String, String>();
 		return logout(returnTo, nameId, sessionIndex, stay, nameidFormat,
 				nameIdNameQualifier, nameIdSPNameQualifier, parameters);
@@ -528,12 +526,11 @@ public class Auth {
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier, Map<String, String> parameters)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 
 		if (parameters == null) {
 			parameters = new HashMap<String, String>();
@@ -593,11 +590,10 @@ public class Auth {
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
-			String nameIdNameQualifier) throws IOException, XMLEntityException, SettingsException {
+			String nameIdNameQualifier) throws IOException, SettingsException {
 		return logout(returnTo, nameId, sessionIndex, stay, nameidFormat, nameIdNameQualifier, null);
 	}
 
@@ -618,11 +614,10 @@ public class Auth {
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay, String nameidFormat)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 		return logout(returnTo, nameId, sessionIndex, stay, nameidFormat, null);
 	}
 
@@ -642,11 +637,10 @@ public class Auth {
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public String logout(String returnTo, String nameId, String sessionIndex, Boolean stay)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 		return logout(returnTo, nameId, sessionIndex, stay, null);
 	}
 
@@ -668,12 +662,11 @@ public class Auth {
 	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
 	 *                              the LogoutRequest.
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public void logout(String returnTo, String nameId, String sessionIndex, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 		logout(returnTo, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier);
 	}
 
@@ -693,11 +686,10 @@ public class Auth {
 	 *                            LogoutRequest.
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public void logout(String returnTo, String nameId, String sessionIndex, String nameidFormat,
-			String nameIdNameQualifier) throws IOException, XMLEntityException, SettingsException {
+			String nameIdNameQualifier) throws IOException, SettingsException {
 		logout(returnTo, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier);
 	}
 
@@ -713,11 +705,10 @@ public class Auth {
 	 *                     process).
 	 * @param nameidFormat The NameID Format will be set in the LogoutRequest.
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public void logout(String returnTo, String nameId, String sessionIndex, String nameidFormat)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 		logout(returnTo, nameId, sessionIndex, false, nameidFormat);
 	}
 
@@ -733,11 +724,10 @@ public class Auth {
 	 *                     process).
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
 	public void logout(String returnTo, String nameId, String sessionIndex)
-			throws IOException, XMLEntityException, SettingsException {
+			throws IOException, SettingsException {
 		logout(returnTo, nameId, sessionIndex, false, null);
 	}
 
@@ -745,10 +735,9 @@ public class Auth {
 	 * Initiates the SLO process.
 	 * 
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout() throws IOException, XMLEntityException, SettingsException {
+	public void logout() throws IOException, SettingsException {
 		logout(null, null, null, false);
 	}
 
@@ -760,10 +749,9 @@ public class Auth {
 	 *                 appended at all when an empty string is provided
 	 *
 	 * @throws IOException
-	 * @throws XMLEntityException
 	 * @throws SettingsException
 	 */
-	public void logout(String returnTo) throws IOException, XMLEntityException, SettingsException {
+	public void logout(String returnTo) throws IOException, SettingsException {
 		logout(returnTo, null, null);
 	}
 


### PR DESCRIPTION
This exception is indeed never thrown and it's a checked one, so it
makes using Auth.logout heavier then necessary. java-saml already has an
abundance of checked exceptions to handle, some of which could easily
be translated into unchecked ones or caught and recovered cleanly, this
is why I think that, if a useless exception declaration is found, it
should better be removed.
This indeed is a small source-incompatible change as soon as the
consumer code is catching XMLEntityException explicitly (rather than
SAMLException, Exception or Throwable). However, fixing this is trivial,
just remove XMLEntityException from the catch clause (which will never
be triggered anyway).