### PR TITLE
Remove the useless Exception throws declaration in LogoutRequest.isValid

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -358,14 +358,12 @@ public class LogoutRequest {
 		return template;
 	}
 
-	 /**
-     * Determines if the SAML LogoutRequest is valid or not
-     *
-     * @return true if the SAML LogoutRequest is valid
-     *
-	 * @throws Exception
-     */
-	public Boolean isValid() throws Exception {
+	/**
+       * Determines if the SAML LogoutRequest is valid or not
+       *
+       * @return true if the SAML LogoutRequest is valid
+       */
+	public Boolean isValid() {
 		validationException = null;
 
 		try {


### PR DESCRIPTION
Two reasons for removal:
- avoid the need of a useless try/catch on consuming code
- align API to LogoutResponse.isValid() and SamlResponse.isValid()

The code is backward compatible, because an existing surrounding
try/catch(Exception) won't cause a compilation error after the change.