### PR TITLE
Improve authentication and logout request input params API

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequest.java
@@ -119,7 +119,7 @@ public class AuthnRequest {
 		LOGGER.debug("AuthNRequest --> " + authnRequestString);
 	}
 
-	/*
+	/**
 	 * Allows for an extension class to post-process the AuthnRequest XML generated
 	 * for this request, in order to customize the result.
 	 * <p>

--- a/core/src/main/java/com/onelogin/saml2/authn/AuthnRequestParams.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/AuthnRequestParams.java
@@ -1,0 +1,105 @@
+package com.onelogin.saml2.authn;
+
+/**
+ * Input parameters for a SAML 2 authentication request.
+ */
+public class AuthnRequestParams {
+
+	/**
+	 * When true the AuthNRequest will set the ForceAuthn='true'
+	 */
+	private final boolean forceAuthn;
+	/**
+	 * When true the AuthNRequest will set the IsPassive='true'
+	 */
+	private final boolean isPassive;
+	/**
+	 * When true the AuthNReuqest will set a nameIdPolicy
+	 */
+	private final boolean setNameIdPolicy;
+	/**
+	 * Indicates to the IdP the subject that should be authenticated
+	 */
+	private final String nameIdValueReq;
+
+	/**
+	 * Create a set of authentication request input parameters.
+	 *
+	 * @param forceAuthn
+	 *              whether the <code>ForceAuthn</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param isPassive
+	 *              whether the <code>isPassive</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param setNameIdPolicy
+	 *              whether a <code>NameIDPolicy</code> should be set
+	 */
+	public AuthnRequestParams(boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy) {
+		this(forceAuthn, isPassive, setNameIdPolicy, null);
+	}
+
+	/**
+	 * Create a set of authentication request input parameters.
+	 *
+	 * @param forceAuthn
+	 *              whether the <code>ForceAuthn</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param isPassive
+	 *              whether the <code>isPassive</code> attribute should be set to
+	 *              <code>true</code>
+	 * @param setNameIdPolicy
+	 *              whether a <code>NameIDPolicy</code> should be set
+	 * @param nameIdValueReq
+	 *              the subject that should be authenticated
+	 */
+	public AuthnRequestParams(boolean forceAuthn, boolean isPassive, boolean setNameIdPolicy, String nameIdValueReq) {
+		this.forceAuthn = forceAuthn;
+		this.isPassive = isPassive;
+		this.setNameIdPolicy = setNameIdPolicy;
+		this.nameIdValueReq = nameIdValueReq;
+	}
+
+	/**
+	 * Create a set of authentication request input parameters, by copying them from
+	 * another set.
+	 *
+	 * @param source
+	 *              the source set of authentication request input parameters
+	 */
+	protected AuthnRequestParams(AuthnRequestParams source) {
+		this.forceAuthn = source.isForceAuthn();
+		this.isPassive = source.isPassive();
+		this.setNameIdPolicy = source.isSetNameIdPolicy();
+		this.nameIdValueReq = source.getNameIdValueReq();
+	}
+
+	/**
+	 * @return whether the <code>ForceAuthn</code> attribute should be set to
+	 *         <code>true</code>
+	 */
+	protected boolean isForceAuthn() {
+		return forceAuthn;
+	}
+
+	/**
+	 * @return whether the <code>isPassive</code> attribute should be set to
+	 *         <code>true</code>
+	 */
+	protected boolean isPassive() {
+		return isPassive;
+	}
+
+	/**
+	 * @return whether a <code>NameIDPolicy</code> should be set
+	 */
+	protected boolean isSetNameIdPolicy() {
+		return setNameIdPolicy;
+	}
+
+	/**
+	 * @return the subject that should be authenticated
+	 */
+	protected String getNameIdValueReq() {
+		return nameIdValueReq;
+	}
+}

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequest.java
@@ -80,17 +80,19 @@ public class LogoutRequest {
 	 * @param settings
 	 *              OneLogin_Saml2_Settings
 	 * @param request
-     *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
+	 *              the HttpRequest object to be processed (Contains GET and POST
+	 *              parameters, request URL, ...).
 	 * @param nameId
 	 *              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex
-	 *              The SessionIndex (taken from the SAML Response in the SSO process).
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
 	 * @param nameIdFormat
 	 *              The nameIdFormat that will be set in the LogoutRequest.
 	 * @param nameIdNameQualifier
-	 *				The NameID NameQualifier that will be set in the LogoutRequest.
+	 *              The NameID NameQualifier that will be set in the LogoutRequest.
 	 * @param nameIdSPNameQualifier
-	 *				The SP Name Qualifier that will be set in the LogoutRequest.
+	 *              The SP Name Qualifier that will be set in the LogoutRequest.
 	 *
 	 * @deprecated use {@link #LogoutRequest(Saml2Settings, HttpRequest)} to build a
 	 *             received request from the HTTP request, or
@@ -131,15 +133,17 @@ public class LogoutRequest {
 	 * @param settings
 	 *              OneLogin_Saml2_Settings
 	 * @param request
-     *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
+	 *              the HttpRequest object to be processed (Contains GET and POST
+	 *              parameters, request URL, ...).
 	 * @param nameId
 	 *              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex
-	 *              The SessionIndex (taken from the SAML Response in the SSO process).
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
 	 * @param nameIdFormat
 	 *              The nameIdFormat that will be set in the LogoutRequest.
 	 * @param nameIdNameQualifier
-	 *				The NameID NameQualifier will be set in the LogoutRequest.
+	 *              The NameID NameQualifier will be set in the LogoutRequest.
 	 *
 	 * @deprecated use {@link #LogoutRequest(Saml2Settings, HttpRequest)} to build a
 	 *             received request from the HTTP request, or
@@ -158,11 +162,13 @@ public class LogoutRequest {
 	 * @param settings
 	 *              OneLogin_Saml2_Settings
 	 * @param request
-     *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
+	 *              the HttpRequest object to be processed (Contains GET and POST
+	 *              parameters, request URL, ...).
 	 * @param nameId
 	 *              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex
-	 *              The SessionIndex (taken from the SAML Response in the SSO process).
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
 	 * @param nameIdFormat
 	 *              The nameIdFormat that will be set in the LogoutRequest.
 	 *
@@ -183,11 +189,13 @@ public class LogoutRequest {
 	 * @param settings
 	 *              OneLogin_Saml2_Settings
 	 * @param request
-     *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
+	 *              the HttpRequest object to be processed (Contains GET and POST
+	 *              parameters, request URL, ...).
 	 * @param nameId
 	 *              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex
-	 *              The SessionIndex (taken from the SAML Response in the SSO process).
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
 	 *
 	 * @deprecated use {@link #LogoutRequest(Saml2Settings, HttpRequest)} to build a
 	 *             received request from the HTTP request, or
@@ -201,11 +209,11 @@ public class LogoutRequest {
 	}
 
 	/**
-	 * Constructs a LogoutRequest object when a new request should be generated
-	 * and sent.
+	 * Constructs a LogoutRequest object when a new request should be generated and
+	 * sent.
 	 *
 	 * @param settings
-	 *            OneLogin_Saml2_Settings
+	 *              OneLogin_Saml2_Settings
 	 *
 	 * @see #LogoutRequest(Saml2Settings, LogoutRequestParams)
 	 */
@@ -214,13 +222,14 @@ public class LogoutRequest {
 	}
 
 	/**
-	 * Constructs the LogoutRequest object when a received request should be extracted
-	 * from the HTTP request and parsed.
+	 * Constructs the LogoutRequest object when a received request should be
+	 * extracted from the HTTP request and parsed.
 	 *
 	 * @param settings
-	 *            OneLogin_Saml2_Settings
+	 *              OneLogin_Saml2_Settings
 	 * @param request
-       *              the HttpRequest object to be processed (Contains GET and POST parameters, request URL, ...).
+	 *              the HttpRequest object to be processed (Contains GET and POST
+	 *              parameters, request URL, ...).
 	 */
 	public LogoutRequest(Saml2Settings settings, HttpRequest request) {
 		this(settings, request, null, null);

--- a/core/src/main/java/com/onelogin/saml2/logout/LogoutRequestParams.java
+++ b/core/src/main/java/com/onelogin/saml2/logout/LogoutRequestParams.java
@@ -1,0 +1,162 @@
+package com.onelogin.saml2.logout;
+
+/**
+ * Input parameters for a SAML 2 logout request.
+ */
+public class LogoutRequestParams {
+
+	/**
+	 * SessionIndex. When the user is logged, this stored it from the AuthnStatement
+	 * of the SAML Response
+	 */
+	private String sessionIndex;
+
+	/**
+	 * NameID.
+	 */
+	private String nameId;
+
+	/**
+	 * NameID Format.
+	 */
+	private String nameIdFormat;
+
+	/**
+	 * nameId NameQualifier
+	 */
+	private String nameIdNameQualifier;
+
+	/**
+	 * nameId SP NameQualifier
+	 */
+	private String nameIdSPNameQualifier;
+
+	/** Create an empty set of logout request input parameters. */
+	public LogoutRequestParams() {
+	}
+
+	/**
+	 * Create a set of logout request input parameters.
+	 *
+	 * @param sessionIndex
+	 *              the session index
+	 * @param nameId
+	 *              the name id of the user to log out
+	 */
+	public LogoutRequestParams(String sessionIndex, String nameId) {
+		this(sessionIndex, nameId, null, null, null);
+	}
+
+	/**
+	 * Create a set of logout request input parameters.
+	 *
+	 * @param sessionIndex
+	 *              the session index
+	 * @param nameId
+	 *              the name id of the user to log out
+	 * @param nameIdFormat
+	 *              the name id format
+	 */
+	public LogoutRequestParams(String sessionIndex, String nameId, String nameIdFormat) {
+		this(sessionIndex, nameId, nameIdFormat, null, null);
+	}
+
+	/**
+	 * Create a set of logout request input parameters.
+	 *
+	 * @param sessionIndex
+	 *              the session index
+	 * @param nameId
+	 *              the name id of the user to log out
+	 * @param nameIdFormat
+	 *              the name id format
+	 * @param nameIdNameQualifier
+	 *              the name id qualifier
+	 */
+	public LogoutRequestParams(String sessionIndex, String nameId, String nameIdFormat, String nameIdNameQualifier) {
+		this(sessionIndex, nameId, nameIdFormat, nameIdNameQualifier, null);
+	}
+
+	/**
+	 * Create a set of logout request input parameters.
+	 *
+	 * @param sessionIndex
+	 *              the session index
+	 * @param nameId
+	 *              the name id of the user to log out
+	 * @param nameIdFormat
+	 *              the name id format
+	 * @param nameIdNameQualifier
+	 *              the name id qualifier
+	 * @param nameIdSPNameQualifier
+	 *              the name id SP qualifier
+	 */
+	public LogoutRequestParams(String sessionIndex, String nameId, String nameIdFormat, String nameIdNameQualifier,
+	            String nameIdSPNameQualifier) {
+		this.sessionIndex = sessionIndex;
+		this.nameId = nameId;
+		this.nameIdFormat = nameIdFormat;
+		this.nameIdNameQualifier = nameIdNameQualifier;
+		this.nameIdSPNameQualifier = nameIdSPNameQualifier;
+	}
+
+	/**
+	 * Create a set of logout request input parameters, by copying them from another
+	 * set.
+	 *
+	 * @param source
+	 *              the source set of logout request input parameters
+	 */
+	protected LogoutRequestParams(LogoutRequestParams source) {
+		this.sessionIndex = source.getSessionIndex();
+		this.nameId = source.getNameId();
+		this.nameIdFormat = source.getNameIdFormat();
+		this.nameIdNameQualifier = source.getNameIdNameQualifier();
+		this.nameIdSPNameQualifier = source.getNameIdSPNameQualifier();
+	}
+
+	/**
+	 * @return the name ID
+	 */
+	protected String getNameId() {
+		return nameId;
+	}
+
+	/**
+	 * Sets the name ID
+	 * 
+	 * @param nameId
+	 *              the name ID to set
+	 */
+	protected void setNameId(String nameId) {
+		this.nameId = nameId;
+	}
+
+	/**
+	 * @return the name ID format
+	 */
+	protected String getNameIdFormat() {
+		return nameIdFormat;
+	}
+
+	/**
+	 * @return the name ID name qualifier
+	 */
+	protected String getNameIdNameQualifier() {
+		return nameIdNameQualifier;
+	}
+
+	/**
+	 * @return the name ID SP name qualifier
+	 */
+	protected String getNameIdSPNameQualifier() {
+		return nameIdSPNameQualifier;
+	}
+
+	/**
+	 * @return the session index
+	 */
+	protected String getSessionIndex() {
+		return sessionIndex;
+	}
+}

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -1,7 +1,5 @@
 package com.onelogin.saml2.settings;
 
-import static com.onelogin.saml2.util.Util.toXml;
-
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Calendar;

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.onelogin.saml2.authn.AuthnRequest;
+import com.onelogin.saml2.authn.AuthnRequestParams;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Util;
@@ -164,13 +165,13 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("ForceAuthn=\"true\"")));
 
-		authnRequest = new AuthnRequest(settings, false, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("ForceAuthn=\"true\"")));		
 
-		authnRequest = new AuthnRequest(settings, true, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(true, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -195,13 +196,13 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("IsPassive=\"true\"")));
 
-		authnRequest = new AuthnRequest(settings, false, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("IsPassive=\"true\"")));		
 
-		authnRequest = new AuthnRequest(settings, false, true, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, true, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -227,13 +228,13 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:NameIDPolicy"));
 		assertThat(authnRequestStr, containsString("Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified\""));
 
-		authnRequest = new AuthnRequest(settings, false, false, false);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("<samlp:NameIDPolicy")));		
 
-		authnRequest = new AuthnRequest(settings, false, false, true);
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, true));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);		
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -365,7 +366,7 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authnRequestStr, not(containsString("<saml:Subject")));
 
-		authnRequest = new AuthnRequest(settings, false, false, false, "testuser@example.com");
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, "testuser@example.com"));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -374,7 +375,7 @@ public class AuthnRequestTest {
 		assertThat(authnRequestStr, containsString("<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">"));
 
 		settings = new SettingsBuilder().fromFile("config/config.emailaddressformat.properties").build();
-		authnRequest = new AuthnRequest(settings, false, false, false, "testuser@example.com");
+		authnRequest = new AuthnRequest(settings, new AuthnRequestParams(false, false, false, "testuser@example.com"));
 		authnRequestStringBase64 = authnRequest.getEncodedAuthnRequest();
 		authnRequestStr = Util.base64decodedInflated(authnRequestStringBase64);
 		assertThat(authnRequestStr, containsString("<samlp:AuthnRequest"));
@@ -523,8 +524,8 @@ public class AuthnRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		AuthnRequest authnRequest = new AuthnRequest(settings) {
 			@Override
-			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
-				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+			protected String postProcessXml(String authRequestXml, AuthnRequestParams params, Saml2Settings sett) {
+				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, params, sett));
 				assertSame(settings, sett);
 				return "changed";
 			}

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnRequestTest.java
@@ -524,8 +524,8 @@ public class AuthnRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		AuthnRequest authnRequest = new AuthnRequest(settings) {
 			@Override
-			protected String postProcessXml(String authRequestXml, AuthnRequestParams params, Saml2Settings sett) {
-				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, params, sett));
+			protected String postProcessXml(String authnRequestXml, AuthnRequestParams params, Saml2Settings sett) {
+				assertEquals(authnRequestXml, super.postProcessXml(authnRequestXml, params, sett));
 				assertSame(settings, sett);
 				return "changed";
 			}

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutRequestTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.onelogin.saml2.logout.LogoutRequest;
-import com.onelogin.saml2.logout.LogoutResponse;
+import com.onelogin.saml2.logout.LogoutRequestParams;
 import com.onelogin.saml2.http.HttpRequest;
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.exception.Error;
@@ -159,14 +159,14 @@ public class LogoutRequestTest {
 	public void testConstructorWithSessionIndex() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		String sessionIndex = "_51be37965feb5579d803141076936dc2e9d1d98ebf";
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, null, sessionIndex);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(sessionIndex, null));
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		String expectedSessionIndex = "<samlp:SessionIndex>_51be37965feb5579d803141076936dc2e9d1d98ebf</samlp:SessionIndex>";
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
 		assertThat(logoutRequestStr, containsString(expectedSessionIndex));
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, null));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -186,14 +186,14 @@ public class LogoutRequestTest {
 	public void testConstructorWithSessionIndexSpecialChars() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		String sessionIndex = "_51be37965feb5579d803141076936dc2e9d1d98ebf&";
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, null, sessionIndex);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(sessionIndex, null));
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		String expectedSessionIndex = "<samlp:SessionIndex>_51be37965feb5579d803141076936dc2e9d1d98ebf&amp;</samlp:SessionIndex>";
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
 		assertThat(logoutRequestStr, containsString(expectedSessionIndex));
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, null));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -276,7 +276,7 @@ public class LogoutRequestTest {
 	@Test
 	public void testGetNameIdData() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -284,7 +284,7 @@ public class LogoutRequestTest {
 		assertThat(nameIdDataStr, containsString("Value=ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		assertThat(nameIdDataStr, not(containsString("SPNameQualifier")));
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, null));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -296,7 +296,7 @@ public class LogoutRequestTest {
 
 		// This settings file contains as IdP cert the SP cert, so I can use the getSPkey to decrypt.
 		settings = new SettingsBuilder().fromFile("config/config.samecerts.properties").build();
-		logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		PrivateKey key = settings.getSPkey();
@@ -304,7 +304,7 @@ public class LogoutRequestTest {
 		assertThat(nameIdDataStr, containsString("Value=ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		assertThat(nameIdDataStr, not(containsString("SPNameQualifier")));
 
-		logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null, "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress");
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		nameIdDataStr = LogoutRequest.getNameIdData(logoutRequestStr, key).toString();
@@ -312,8 +312,8 @@ public class LogoutRequestTest {
 		assertThat(nameIdDataStr, containsString("Value=ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		assertThat(nameIdDataStr, not(containsString("SPNameQualifier")));
 
-  	    String keyString = Util.getFileAsString("data/customPath/certs/sp.pem");
-  	    key = Util.loadPrivateKey(keyString);
+  	    	String keyString = Util.getFileAsString("data/customPath/certs/sp.pem");
+  	    	key = Util.loadPrivateKey(keyString);
 		logoutRequestStr = Util.getFileAsString("data/logout_requests/logout_request_encrypted_nameid.xml");
 		nameIdDataStr = LogoutRequest.getNameIdData(logoutRequestStr, key).toString();
 		assertThat(nameIdDataStr, containsString("Format=urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"));
@@ -321,7 +321,7 @@ public class LogoutRequestTest {
 		assertThat(nameIdDataStr, containsString("SPNameQualifier=https://pitbulk.no-ip.org/newonelogin/demo1/metadata.php"));
 
 		settings = new SettingsBuilder().fromFile("config/config.emailaddressformat.properties").build();
-		logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -330,7 +330,7 @@ public class LogoutRequestTest {
 		assertThat(nameIdDataStr, containsString("Format=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"));
 		assertThat(nameIdDataStr, not(containsString("SPNameQualifier")));
 
-		logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null, Constants.NAMEID_PERSISTENT, settings.getIdpEntityId(), settings.getSpEntityId());
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", Constants.NAMEID_PERSISTENT, settings.getIdpEntityId(), settings.getSpEntityId()));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -353,14 +353,14 @@ public class LogoutRequestTest {
 	@Test
 	public void testGetNameIdDataSpecialChars() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min_specialchars.properties").build();
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, "<ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c>", null);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "<ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c>"));
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
 		assertThat(logoutRequestStr, containsString("<saml:NameID>&lt;ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c&gt;</saml:NameID>"));
 		assertThat(logoutRequestStr, not(containsString("SPNameQualifier")));
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, null));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -432,7 +432,7 @@ public class LogoutRequestTest {
 	public void testGetIssueInstantBuiltMessage() throws Exception  {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		long start = System.currentTimeMillis();
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null);
+		LogoutRequest logoutRequest = new LogoutRequest(settings);
 		long end = System.currentTimeMillis();
 		Calendar issueInstant = logoutRequest.getIssueInstant();
 		assertNotNull(issueInstant);
@@ -520,7 +520,7 @@ public class LogoutRequestTest {
 	@Test
 	public void testGetNameId() throws Exception {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		String logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -528,7 +528,7 @@ public class LogoutRequestTest {
 		String nameIdStr = LogoutRequest.getNameId(logoutRequestStr, null).toString();
 		assertEquals(expectedNameIdStr, nameIdStr);
 
-		logoutRequest = new LogoutRequest(settings, null, null, null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, null));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		assertThat(logoutRequestStr, containsString("<samlp:LogoutRequest"));
@@ -545,7 +545,7 @@ public class LogoutRequestTest {
 
 		// This settings file contains as IdP cert the SP cert, so I can use the getSPkey to decrypt.
 		settings = new SettingsBuilder().fromFile("config/config.samecerts.properties").build();
-		logoutRequest = new LogoutRequest(settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null);
+		logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c"));
 		logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		PrivateKey key = settings.getSPkey();
@@ -679,7 +679,7 @@ public class LogoutRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		String sessionIndex = "_51be37965feb5579d803141076936dc2e9d1d98ebf";
 		expectedIndexes.add(sessionIndex);
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, null, sessionIndex);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, new LogoutRequestParams(sessionIndex, null));
 		String logoutRequestStringBase64 = logoutRequest.getEncodedLogoutRequest();
 		logoutRequestStr = Util.base64decodedInflated(logoutRequestStringBase64);
 		indexes = LogoutRequest.getSessionIndexes(logoutRequestStr);
@@ -1038,7 +1038,7 @@ public class LogoutRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		String samlRequestEncoded = Util.getFileAsString("data/logout_requests/logout_request_deflated.xml.base64");
 
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, (HttpRequest) null);
 		assertFalse(logoutRequest.isValid());
 		assertEquals("The HttpRequest of the current host was not established", logoutRequest.getError());
 
@@ -1097,8 +1097,8 @@ public class LogoutRequestTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		LogoutRequest logoutRequest = new LogoutRequest(settings) {
 			@Override
-			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
-				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+			protected String postProcessXml(String logoutRequestXml, LogoutRequestParams params, Saml2Settings sett) {
+				assertEquals(logoutRequestXml, super.postProcessXml(logoutRequestXml, params, sett));
 				assertSame(settings, sett);
 				return "changed";
 			}

--- a/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/logout/LogoutResponseTest.java
@@ -758,8 +758,8 @@ public class LogoutResponseTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		LogoutResponse logoutResponse = new LogoutResponse(settings, null) {
 			@Override
-			protected String postProcessXml(String authRequestXml, Saml2Settings sett) {
-				assertEquals(authRequestXml, super.postProcessXml(authRequestXml, sett));
+			protected String postProcessXml(String logoutResponseXml, Saml2Settings sett) {
+				assertEquals(logoutResponseXml, super.postProcessXml(logoutResponseXml, sett));
 				assertSame(settings, sett);
 				return "changed";
 			}

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -29,6 +29,7 @@ import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.exception.Error;
 import com.onelogin.saml2.http.HttpRequest;
 import com.onelogin.saml2.logout.LogoutRequest;
+import com.onelogin.saml2.logout.LogoutRequestParams;
 import com.onelogin.saml2.logout.LogoutResponse;
 import com.onelogin.saml2.model.SamlResponseStatus;
 import com.onelogin.saml2.model.KeyStoreSettings;
@@ -645,43 +646,59 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState      	  a state information to pass forth and back between
-	 * 				  	  the Service Provider and the Identity Provider; 
-	 * 				  	  in the most simple case, it may be a URL to which
-	 * 				  	  the logged out user should be redirected after the
-	 * 				  	  logout response has been received back from the 
-	 * 				  	  Identity Provider and validated correctly with
-	 * 				  	  {@link #processSLO()}; please note that SAML 2.0 
-	 * 				  	  specification imposes a limit of max 80 characters for 
-	 * 				  	  this relayState data and that protection strategies 
-	 * 				  	  against tampering should better be implemented;
-	 * 				  	  it will be a self-routed URL when <code>null</code>, 
-	 * 				  	  otherwise no relayState at all will be appended if an empty 
-	 * 				  	  string is provided
-	 * @param nameId                The NameID that will be set in the
-	 *                              LogoutRequest.
-	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
-	 *                              in the SSO process).
-	 * @param stay                  True if we want to stay (returns the url string)
-	 *                              False to execute redirection
-	 * @param nameidFormat          The NameID Format that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdNameQualifier   The NameID NameQualifier that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
-	 *                              the LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param logoutRequestParams
+	 *              the logout request input parameters
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
-			String nameIdNameQualifier, String nameIdSPNameQualifier)
+	public String logout(String relayState, LogoutRequestParams logoutRequestParams, Boolean stay)
 			throws IOException, SettingsException {
 		Map<String, String> parameters = new HashMap<String, String>();
-		return logout(relayState, nameId, sessionIndex, stay, nameidFormat,
-				nameIdNameQualifier, nameIdSPNameQualifier, parameters);
+		return logout(relayState, logoutRequestParams, stay, parameters);
+	}
+
+	/**
+	 * Initiates the SLO process.
+	 *
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param logoutRequestParams
+	 *              the logout request input parameters
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 */
+	public void logout(String relayState, LogoutRequestParams logoutRequestParams)
+			throws IOException, SettingsException {
+		logout(relayState, logoutRequestParams, false);
 	}
 
 	/**
@@ -712,23 +729,58 @@ public class Auth {
 	 *                              LogoutRequest.
 	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
 	 *                              the LogoutRequest.
-	 * @param parameters      	  Use it to send extra parameters in addition to the LogoutRequest
+	 *
+	 * @return the SLO URL with the LogoutRequest if stay = True
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String, String, String)}
+	 *             instead
+	 */
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
+			String nameIdNameQualifier, String nameIdSPNameQualifier)
+			throws IOException, SettingsException {
+		Map<String, String> parameters = new HashMap<String, String>();
+		return logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier), stay, parameters);
+	}
+
+	/**
+	 * Initiates the SLO process.
+	 *
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param logoutRequestParams
+	 *              the logout request input parameters
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param parameters
+	 *              Use it to send extra parameters in addition to the LogoutRequest
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
 	 */
-	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
-			String nameIdNameQualifier, String nameIdSPNameQualifier, Map<String, String> parameters)
+	public String logout(String relayState, LogoutRequestParams logoutRequestParams, Boolean stay, Map<String, String> parameters)
 			throws IOException, SettingsException {
 
 		if (parameters == null) {
 			parameters = new HashMap<String, String>();
 		}
 
-		LogoutRequest logoutRequest = new LogoutRequest(settings, null, nameId, sessionIndex, nameidFormat,
-				nameIdNameQualifier, nameIdSPNameQualifier);
+		LogoutRequest logoutRequest = new LogoutRequest(settings, logoutRequestParams);
 		String samlLogoutRequest = logoutRequest.getEncodedLogoutRequest();
 		parameters.put("SAMLRequest", samlLogoutRequest);
 
@@ -775,6 +827,51 @@ public class Auth {
 	 * 				  	it will be a self-routed URL when <code>null</code>, 
 	 * 				  	otherwise no relayState at all will be appended if an empty 
 	 * 				  	string is provided
+	 * @param nameId                The NameID that will be set in the
+	 *                              LogoutRequest.
+	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
+	 *                              in the SSO process).
+	 * @param stay                  True if we want to stay (returns the url string)
+	 *                              False to execute redirection
+	 * @param nameidFormat          The NameID Format that will be set in the
+	 *                              LogoutRequest.
+	 * @param nameIdNameQualifier   The NameID NameQualifier that will be set in the
+	 *                              LogoutRequest.
+	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
+	 *                              the LogoutRequest.
+	 * @param parameters      		Use it to send extra parameters in addition to the LogoutRequest
+	 *
+	 * @return the SLO URL with the LogoutRequest if stay = True
+	 *
+	 * @throws IOException
+	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean, Map)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String, String, String)}
+	 *             instead
+	 */
+	@Deprecated
+	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
+			String nameIdNameQualifier, String nameIdSPNameQualifier, Map<String, String> parameters)
+			throws IOException, SettingsException {
+		return logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier), stay, parameters);
+	}
+
+	/**
+	 * Initiates the SLO process.
+	 *
+	 * @param relayState      	a state information to pass forth and back between
+	 * 				  	the Service Provider and the Identity Provider; 
+	 * 				  	in the most simple case, it may be a URL to which
+	 * 				  	the logged out user should be redirected after the
+	 * 				  	logout response has been received back from the 
+	 * 				  	Identity Provider and validated correctly with
+	 * 				  	{@link #processSLO()}; please note that SAML 2.0 
+	 * 				  	specification imposes a limit of max 80 characters for 
+	 * 				  	this relayState data and that protection strategies 
+	 * 				  	against tampering should better be implemented;
+	 * 				  	it will be a self-routed URL when <code>null</code>, 
+	 * 				  	otherwise no relayState at all will be appended if an empty 
+	 * 				  	string is provided
 	 * @param nameId              The NameID that will be set in the LogoutRequest.
 	 * @param sessionIndex        The SessionIndex (taken from the SAML Response in
 	 *                            the SSO process).
@@ -789,10 +886,14 @@ public class Auth {
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat,
 			String nameIdNameQualifier) throws IOException, SettingsException {
-		return logout(relayState, nameId, sessionIndex, stay, nameidFormat, nameIdNameQualifier, null);
+		return logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat, nameIdNameQualifier), stay, null);
 	}
 
 	/**
@@ -822,10 +923,14 @@ public class Auth {
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay, String nameidFormat)
 			throws IOException, SettingsException {
-		return logout(relayState, nameId, sessionIndex, stay, nameidFormat, null);
+		return logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat), stay, null);
 	}
 
 	/**
@@ -854,10 +959,14 @@ public class Auth {
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public String logout(String relayState, String nameId, String sessionIndex, Boolean stay)
 			throws IOException, SettingsException {
-		return logout(relayState, nameId, sessionIndex, stay, null);
+		return logout(relayState, new LogoutRequestParams(sessionIndex, nameId), stay, null);
 	}
 
 	/**
@@ -888,11 +997,15 @@ public class Auth {
 	 *                              the LogoutRequest.
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String, String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public void logout(String relayState, String nameId, String sessionIndex, String nameidFormat,
 			String nameIdNameQualifier, String nameIdSPNameQualifier)
 			throws IOException, SettingsException {
-		logout(relayState, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier);
+		logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat, nameIdNameQualifier, nameIdSPNameQualifier), false);
 	}
 
 	/**
@@ -921,10 +1034,14 @@ public class Auth {
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public void logout(String relayState, String nameId, String sessionIndex, String nameidFormat,
 			String nameIdNameQualifier) throws IOException, SettingsException {
-		logout(relayState, nameId, sessionIndex, false, nameidFormat, nameIdNameQualifier);
+		logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat, nameIdNameQualifier), false);
 	}
 
 	/**
@@ -949,10 +1066,14 @@ public class Auth {
 	 * @param nameidFormat The NameID Format will be set in the LogoutRequest.
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public void logout(String relayState, String nameId, String sessionIndex, String nameidFormat)
 			throws IOException, SettingsException {
-		logout(relayState, nameId, sessionIndex, false, nameidFormat);
+		logout(relayState, new LogoutRequestParams(sessionIndex, nameId, nameidFormat), false);
 	}
 
 	/**
@@ -977,10 +1098,14 @@ public class Auth {
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
+	 * @deprecated use {@link #logout(String, LogoutRequestParams)} with
+	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String)}
+	 *             instead
 	 */
+	@Deprecated
 	public void logout(String relayState, String nameId, String sessionIndex)
 			throws IOException, SettingsException {
-		logout(relayState, nameId, sessionIndex, false, null);
+		logout(relayState, new LogoutRequestParams(sessionIndex, nameId), false, null);
 	}
 
 	/**
@@ -990,7 +1115,7 @@ public class Auth {
 	 * @throws SettingsException
 	 */
 	public void logout() throws IOException, SettingsException {
-		logout(null, null, null, false);
+		logout(null, new LogoutRequestParams(), false);
 	}
 
 	/**
@@ -1014,7 +1139,7 @@ public class Auth {
 	 * @throws SettingsException
 	 */
 	public void logout(String relayState) throws IOException, SettingsException {
-		logout(relayState, null, null);
+		logout(relayState, new LogoutRequestParams(), false);
 	}
 
 	/**

--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -322,28 +322,29 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param relayState      a state information to pass forth and back between
-	 * 				  the Service Provider and the Identity Provider; 
-	 * 				  in the most simple case, it may be a URL to which
-	 * 				  the authenticated user should be redirected after the
-	 * 				  authentication response has been received back from the 
-	 * 				  Identity Provider and validated correctly with
-	 * 				  {@link #processResponse()}; please note that SAML 2.0 
-	 * 				  specification imposes a limit of max 80 characters for 
-	 * 				  this relayState data and that protection strategies 
-	 * 				  against tampering should better be implemented;
-	 * 				  it will be a self-routed URL when <code>null</code>, 
-	 * 				  otherwise no relayState at all will be appended if an empty 
-	 * 				  string is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 * @param stay            True if we want to stay (returns the url string) False
-	 *                        to execute redirection
-	 * @param nameIdValueReq  Indicates to the IdP the subject that should be
-	 *                        authenticated
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the authenticated user should be
+	 *              redirected after the authentication response has been received
+	 *              back from the Identity Provider and validated correctly with
+	 *              {@link #processResponse()}; please note that SAML 2.0
+	 *              specification imposes a limit of max 80 characters for this
+	 *              relayState data and that protection strategies against tampering
+	 *              should better be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameIdValueReq
+	 *              Indicates to the IdP the subject that should be authenticated
 	 *
 	 * @return the SSO URL with the AuthNRequest if stay = True
 	 *
@@ -364,29 +365,31 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param relayState      a state information to pass forth and back between
-	 * 				  the Service Provider and the Identity Provider; 
-	 * 				  in the most simple case, it may be a URL to which
-	 * 				  the authenticated user should be redirected after the
-	 * 				  authentication response has been received back from the 
-	 * 				  Identity Provider and validated correctly with
-	 * 				  {@link #processResponse()}; please note that SAML 2.0 
-	 * 				  specification imposes a limit of max 80 characters for 
-	 * 				  this relayState data and that protection strategies 
-	 * 				  against tampering should better be implemented;
-	 * 				  it will be a self-routed URL when <code>null</code>, 
-	 * 				  otherwise no relayState at all will be appended if an empty 
-	 * 				  string is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 * @param stay            True if we want to stay (returns the url string) False
-	 *                        to execute redirection
-	 * @param nameIdValueReq  Indicates to the IdP the subject that should be
-	 *                        authenticated
-	 * @param parameters      Use it to send extra parameters in addition to the AuthNRequest
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the authenticated user should be
+	 *              redirected after the authentication response has been received
+	 *              back from the Identity Provider and validated correctly with
+	 *              {@link #processResponse()}; please note that SAML 2.0
+	 *              specification imposes a limit of max 80 characters for this
+	 *              relayState data and that protection strategies against tampering
+	 *              should better be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameIdValueReq
+	 *              Indicates to the IdP the subject that should be authenticated
+	 * @param parameters
+	 *              Use it to send extra parameters in addition to the AuthNRequest
 	 *
 	 * @return the SSO URL with the AuthNRequest if stay = True
 	 *
@@ -406,26 +409,27 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param relayState      a state information to pass forth and back between
-	 * 				  the Service Provider and the Identity Provider; 
-	 * 				  in the most simple case, it may be a URL to which
-	 * 				  the authenticated user should be redirected after the
-	 * 				  authentication response has been received back from the 
-	 * 				  Identity Provider and validated correctly with
-	 * 				  {@link #processResponse()}; please note that SAML 2.0 
-	 * 				  specification imposes a limit of max 80 characters for 
-	 * 				  this relayState data and that protection strategies 
-	 * 				  against tampering should better be implemented;
-	 * 				  it will be a self-routed URL when <code>null</code>, 
-	 * 				  otherwise no relayState at all will be appended if an empty 
-	 * 				  string is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
-	 * @param stay            True if we want to stay (returns the url string) False
-	 *                        to execute redirection
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the authenticated user should be
+	 *              redirected after the authentication response has been received
+	 *              back from the Identity Provider and validated correctly with
+	 *              {@link #processResponse()}; please note that SAML 2.0
+	 *              specification imposes a limit of max 80 characters for this
+	 *              relayState data and that protection strategies against tampering
+	 *              should better be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
 	 *
 	 * @return the SSO URL with the AuthNRequest if stay = True
 	 *
@@ -444,24 +448,24 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param relayState      a state information to pass forth and back between
-	 * 				  the Service Provider and the Identity Provider; 
-	 * 				  in the most simple case, it may be a URL to which
-	 * 				  the authenticated user should be redirected after the
-	 * 				  authentication response has been received back from the 
-	 * 				  Identity Provider and validated correctly with
-	 * 				  {@link #processResponse()}; please note that SAML 2.0 
-	 * 				  specification imposes a limit of max 80 characters for 
-	 * 				  this relayState data and that protection strategies 
-	 * 				  against tampering should better be implemented;
-	 * 				  it will be a self-routed URL when <code>null</code>, 
-	 * 				  otherwise no relayState at all will be appended if an empty 
-	 * 				  string is provided
-	 * @param forceAuthn      When true the AuthNRequest will set the
-	 *                        ForceAuthn='true'
-	 * @param isPassive       When true the AuthNRequest will set the
-	 *                        IsPassive='true'
-	 * @param setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the authenticated user should be
+	 *              redirected after the authentication response has been received
+	 *              back from the Identity Provider and validated correctly with
+	 *              {@link #processResponse()}; please note that SAML 2.0
+	 *              specification imposes a limit of max 80 characters for this
+	 *              relayState data and that protection strategies against tampering
+	 *              should better be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param forceAuthn
+	 *              When true the AuthNRequest will set the ForceAuthn='true'
+	 * @param isPassive
+	 *              When true the AuthNRequest will set the IsPassive='true'
+	 * @param setNameIdPolicy
+	 *              When true the AuthNRequest will set a nameIdPolicy
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
@@ -501,19 +505,18 @@ public class Auth {
 	/**
 	 * Initiates the SSO process.
 	 *
-	 * @param relayState a state information to pass forth and back between
-	 * 			   the Service Provider and the Identity Provider; 
-	 * 			   in the most simple case, it may be a URL to which
-	 * 			   the authenticated user should be redirected after the
-	 * 			   authentication response has been received back from the 
-	 * 			   Identity Provider and validated correctly with
-	 * 			   {@link #processResponse()}; please note that SAML 2.0 
-	 * 			   specification imposes a limit of max 80 characters for 
-	 * 			   this relayState data and that protection strategies 
-	 * 			   against tampering should better be implemented;
-	 * 			   it will be a self-routed URL when <code>null</code>, 
-	 * 			   otherwise no relayState at all will be appended if an empty 
-	 * 			   string is provided
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the authenticated user should be
+	 *              redirected after the authentication response has been received
+	 *              back from the Identity Provider and validated correctly with
+	 *              {@link #processResponse()}; please note that SAML 2.0
+	 *              specification imposes a limit of max 80 characters for this
+	 *              relayState data and that protection strategies against tampering
+	 *              should better be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
@@ -704,31 +707,33 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState      	  a state information to pass forth and back between
-	 * 				  	  the Service Provider and the Identity Provider; 
-	 * 				  	  in the most simple case, it may be a URL to which
-	 * 				  	  the logged out user should be redirected after the
-	 * 				  	  logout response has been received back from the 
-	 * 				  	  Identity Provider and validated correctly with
-	 * 				  	  {@link #processSLO()}; please note that SAML 2.0 
-	 * 				  	  specification imposes a limit of max 80 characters for 
-	 * 				  	  this relayState data and that protection strategies 
-	 * 				  	  against tampering should better be implemented;
-	 * 				  	  it will be a self-routed URL when <code>null</code>, 
-	 * 				  	  otherwise no relayState at all will be appended if an empty 
-	 * 				  	  string is provided
-	 * @param nameId                The NameID that will be set in the
-	 *                              LogoutRequest.
-	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
-	 *                              in the SSO process).
-	 * @param stay                  True if we want to stay (returns the url string)
-	 *                              False to execute redirection
-	 * @param nameidFormat          The NameID Format that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdNameQualifier   The NameID NameQualifier that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
-	 *                              the LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameidFormat
+	 *              The NameID Format that will be set in the LogoutRequest.
+	 * @param nameIdNameQualifier
+	 *              The NameID NameQualifier that will be set in the LogoutRequest.
+	 * @param nameIdSPNameQualifier
+	 *              The NameID SP Name Qualifier that will be set in the
+	 *              LogoutRequest.
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
@@ -814,38 +819,42 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState      	a state information to pass forth and back between
-	 * 				  	the Service Provider and the Identity Provider; 
-	 * 				  	in the most simple case, it may be a URL to which
-	 * 				  	the logged out user should be redirected after the
-	 * 				  	logout response has been received back from the 
-	 * 				  	Identity Provider and validated correctly with
-	 * 				  	{@link #processSLO()}; please note that SAML 2.0 
-	 * 				  	specification imposes a limit of max 80 characters for 
-	 * 				  	this relayState data and that protection strategies 
-	 * 				  	against tampering should better be implemented;
-	 * 				  	it will be a self-routed URL when <code>null</code>, 
-	 * 				  	otherwise no relayState at all will be appended if an empty 
-	 * 				  	string is provided
-	 * @param nameId                The NameID that will be set in the
-	 *                              LogoutRequest.
-	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
-	 *                              in the SSO process).
-	 * @param stay                  True if we want to stay (returns the url string)
-	 *                              False to execute redirection
-	 * @param nameidFormat          The NameID Format that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdNameQualifier   The NameID NameQualifier that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
-	 *                              the LogoutRequest.
-	 * @param parameters      		Use it to send extra parameters in addition to the LogoutRequest
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameidFormat
+	 *              The NameID Format that will be set in the LogoutRequest.
+	 * @param nameIdNameQualifier
+	 *              The NameID NameQualifier that will be set in the LogoutRequest.
+	 * @param nameIdSPNameQualifier
+	 *              The NameID SP Name Qualifier that will be set in the
+	 *              LogoutRequest.
+	 * @param parameters
+	 *              Use it to send extra parameters in addition to the LogoutRequest
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
-	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean, Map)} with
+	 * @deprecated use {@link #logout(String, LogoutRequestParams, Boolean, Map)}
+	 *             with
 	 *             {@link LogoutRequestParams#LogoutRequestParams(String, String, String, String, String)}
 	 *             instead
 	 */
@@ -859,28 +868,30 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState      	a state information to pass forth and back between
-	 * 				  	the Service Provider and the Identity Provider; 
-	 * 				  	in the most simple case, it may be a URL to which
-	 * 				  	the logged out user should be redirected after the
-	 * 				  	logout response has been received back from the 
-	 * 				  	Identity Provider and validated correctly with
-	 * 				  	{@link #processSLO()}; please note that SAML 2.0 
-	 * 				  	specification imposes a limit of max 80 characters for 
-	 * 				  	this relayState data and that protection strategies 
-	 * 				  	against tampering should better be implemented;
-	 * 				  	it will be a self-routed URL when <code>null</code>, 
-	 * 				  	otherwise no relayState at all will be appended if an empty 
-	 * 				  	string is provided
-	 * @param nameId              The NameID that will be set in the LogoutRequest.
-	 * @param sessionIndex        The SessionIndex (taken from the SAML Response in
-	 *                            the SSO process).
-	 * @param stay                True if we want to stay (returns the url string)
-	 *                            False to execute redirection
-	 * @param nameidFormat        The NameID Format will be set in the
-	 *                            LogoutRequest.
-	 * @param nameIdNameQualifier The NameID NameQualifier will be set in the
-	 *                            LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameidFormat
+	 *              The NameID Format will be set in the LogoutRequest.
+	 * @param nameIdNameQualifier
+	 *              The NameID NameQualifier will be set in the LogoutRequest.
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
@@ -899,25 +910,28 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState   a state information to pass forth and back between
-	 * 			     the Service Provider and the Identity Provider; 
-	 * 			     in the most simple case, it may be a URL to which
-	 * 			     the logged out user should be redirected after the
-	 * 			     logout response has been received back from the 
-	 * 			     Identity Provider and validated correctly with
-	 * 			     {@link #processSLO()}; please note that SAML 2.0 
-	 * 			     specification imposes a limit of max 80 characters for 
-	 * 			     this relayState data and that protection strategies 
-	 * 			     against tampering should better be implemented;
-	 * 			     it will be a self-routed URL when <code>null</code>, 
-	 * 			     otherwise no relayState at all will be appended if an empty 
-	 * 			     string is provided
-	 * @param nameId       The NameID that will be set in the LogoutRequest.
-	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
-	 *                     process).
-	 * @param stay         True if we want to stay (returns the url string) False to
-	 *                     execute redirection
-	 * @param nameidFormat The NameID Format will be set in the LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
+	 * @param nameidFormat
+	 *              The NameID Format will be set in the LogoutRequest.
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
@@ -936,24 +950,26 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState   a state information to pass forth and back between
-	 * 			     the Service Provider and the Identity Provider; 
-	 * 			     in the most simple case, it may be a URL to which
-	 * 			     the logged out user should be redirected after the
-	 * 			     logout response has been received back from the 
-	 * 			     Identity Provider and validated correctly with
-	 * 			     {@link #processSLO()}; please note that SAML 2.0 
-	 * 			     specification imposes a limit of max 80 characters for 
-	 * 			     this relayState data and that protection strategies 
-	 * 			     against tampering should better be implemented;
-	 * 			     it will be a self-routed URL when <code>null</code>, 
-	 * 			     otherwise no relayState at all will be appended if an empty 
-	 * 			     string is provided
-	 * @param nameId       The NameID that will be set in the LogoutRequest.
-	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
-	 *                     process).
-	 * @param stay         True if we want to stay (returns the url string) False to
-	 *                     execute redirection
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param stay
+	 *              True if we want to stay (returns the url string) False to
+	 *              execute redirection
 	 *
 	 * @return the SLO URL with the LogoutRequest if stay = True
 	 *
@@ -972,29 +988,30 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState   		  a state information to pass forth and back between
-	 * 			     		  the Service Provider and the Identity Provider; 
-	 * 			     		  in the most simple case, it may be a URL to which
-	 * 			     		  the logged out user should be redirected after the
-	 * 			     		  logout response has been received back from the 
-	 * 			     		  Identity Provider and validated correctly with
-	 * 			     		  {@link #processSLO()}; please note that SAML 2.0 
-	 * 			     		  specification imposes a limit of max 80 characters for 
-	 * 			     		  this relayState data and that protection strategies 
-	 * 			     		  against tampering should better be implemented;
-	 * 			     		  it will be a self-routed URL when <code>null</code>, 
-	 * 			     		  otherwise no relayState at all will be appended if an empty 
-	 * 			     		  string is provided
-	 * @param nameId                The NameID that will be set in the
-	 *                              LogoutRequest.
-	 * @param sessionIndex          The SessionIndex (taken from the SAML Response
-	 *                              in the SSO process).
-	 * @param nameidFormat          The NameID Format will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdNameQualifier   The NameID NameQualifier that will be set in the
-	 *                              LogoutRequest.
-	 * @param nameIdSPNameQualifier The NameID SP Name Qualifier that will be set in
-	 *                              the LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param nameidFormat
+	 *              The NameID Format will be set in the LogoutRequest.
+	 * @param nameIdNameQualifier
+	 *              The NameID NameQualifier that will be set in the LogoutRequest.
+	 * @param nameIdSPNameQualifier
+	 *              The NameID SP Name Qualifier that will be set in the
+	 *              LogoutRequest.
 	 * @throws IOException
 	 * @throws SettingsException
 	 * @deprecated use {@link #logout(String, LogoutRequestParams)} with
@@ -1011,26 +1028,27 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState   		a state information to pass forth and back between
-	 * 			     		the Service Provider and the Identity Provider; 
-	 * 			     		in the most simple case, it may be a URL to which
-	 * 			     		the logged out user should be redirected after the
-	 * 			     		logout response has been received back from the 
-	 * 			     		Identity Provider and validated correctly with
-	 * 			     		{@link #processSLO()}; please note that SAML 2.0 
-	 * 			     		specification imposes a limit of max 80 characters for 
-	 * 			     		this relayState data and that protection strategies 
-	 * 			     		against tampering should better be implemented;
-	 * 			     		it will be a self-routed URL when <code>null</code>, 
-	 * 			     		otherwise no relayState at all will be appended if an empty 
-	 * 			     		string is provided
-	 * @param nameId              The NameID that will be set in the LogoutRequest.
-	 * @param sessionIndex        The SessionIndex (taken from the SAML Response in
-	 *                            the SSO process).
-	 * @param nameidFormat        The NameID Format will be set in the
-	 *                            LogoutRequest.
-	 * @param nameIdNameQualifier The NameID NameQualifier will be set in the
-	 *                            LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param nameidFormat
+	 *              The NameID Format will be set in the LogoutRequest.
+	 * @param nameIdNameQualifier
+	 *              The NameID NameQualifier will be set in the LogoutRequest.
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
@@ -1047,23 +1065,25 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState a state information to pass forth and back between
-	 * 			   the Service Provider and the Identity Provider; 
-	 * 			   in the most simple case, it may be a URL to which
-	 * 			   the logged out user should be redirected after the
-	 * 			   logout response has been received back from the 
-	 * 			   Identity Provider and validated correctly with
-	 * 			   {@link #processSLO()}; please note that SAML 2.0 
-	 * 			   specification imposes a limit of max 80 characters for 
-	 * 			   this relayState data and that protection strategies 
-	 * 			   against tampering should better be implemented;
-	 * 			   it will be a self-routed URL when <code>null</code>, 
-	 * 			   otherwise no relayState at all will be appended if an empty 
-	 * 			   string is provided
-	 * @param nameId       The NameID that will be set in the LogoutRequest.
-	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
-	 *                     process).
-	 * @param nameidFormat The NameID Format will be set in the LogoutRequest.
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
+	 * @param nameidFormat
+	 *              The NameID Format will be set in the LogoutRequest.
 	 * @throws IOException
 	 * @throws SettingsException
 	 * @deprecated use {@link #logout(String, LogoutRequestParams)} with
@@ -1079,22 +1099,23 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState   a state information to pass forth and back between
-	 * 			     the Service Provider and the Identity Provider; 
-	 * 			     in the most simple case, it may be a URL to which
-	 * 			     the logged out user should be redirected after the
-	 * 			     logout response has been received back from the 
-	 * 			     Identity Provider and validated correctly with
-	 * 			     {@link #processSLO()}; please note that SAML 2.0 
-	 * 			     specification imposes a limit of max 80 characters for 
-	 * 			     this relayState data and that protection strategies 
-	 * 			     against tampering should better be implemented;
-	 * 			     it will be a self-routed URL when <code>null</code>, 
-	 * 			     otherwise no relayState at all will be appended if an empty 
-	 * 			     string is provided
-	 * @param nameId       The NameID that will be set in the LogoutRequest.
-	 * @param sessionIndex The SessionIndex (taken from the SAML Response in the SSO
-	 *                     process).
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
+	 * @param nameId
+	 *              The NameID that will be set in the LogoutRequest.
+	 * @param sessionIndex
+	 *              The SessionIndex (taken from the SAML Response in the SSO
+	 *              process).
 	 *
 	 * @throws IOException
 	 * @throws SettingsException
@@ -1121,19 +1142,18 @@ public class Auth {
 	/**
 	 * Initiates the SLO process.
 	 *
-	 * @param relayState a state information to pass forth and back between
-	 * 			   the Service Provider and the Identity Provider; 
-	 * 			   in the most simple case, it may be a URL to which
-	 * 			   the logged out user should be redirected after the
-	 * 			   logout response has been received back from the 
-	 * 			   Identity Provider and validated correctly with
-	 * 			   {@link #processSLO()}; please note that SAML 2.0 
-	 * 			   specification imposes a limit of max 80 characters for 
-	 * 			   this relayState data and that protection strategies 
-	 * 			   against tampering should better be implemented;
-	 * 			   it will be a self-routed URL when <code>null</code>, 
-	 * 			   otherwise no relayState at all will be appended if an empty 
-	 * 			   string is provided
+	 * @param relayState
+	 *              a state information to pass forth and back between the Service
+	 *              Provider and the Identity Provider; in the most simple case, it
+	 *              may be a URL to which the logged out user should be redirected
+	 *              after the logout response has been received back from the
+	 *              Identity Provider and validated correctly with
+	 *              {@link #processSLO()}; please note that SAML 2.0 specification
+	 *              imposes a limit of max 80 characters for this relayState data
+	 *              and that protection strategies against tampering should better
+	 *              be implemented; it will be a self-routed URL when
+	 *              <code>null</code>, otherwise no relayState at all will be
+	 *              appended if an empty string is provided
 	 *
 	 * @throws IOException
 	 * @throws SettingsException

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -52,6 +52,7 @@ import com.onelogin.saml2.exception.Error;
 import com.onelogin.saml2.exception.SettingsException;
 import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.exception.XMLEntityException;
+import com.onelogin.saml2.logout.LogoutRequestParams;
 import com.onelogin.saml2.model.KeyStoreSettings;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
@@ -1586,7 +1587,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		Map<String, String> extraParameters = new HashMap<String, String>();
 		extraParameters.put("parameter1", "xxx");
-		String target = auth.logout("", null, null, true, null, null, null, extraParameters);
+		String target = auth.logout("", new LogoutRequestParams(), true, extraParameters);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SingleLogoutService.php?SAMLRequest="));
 		assertThat(target, containsString("&parameter1=xxx"));
 	}
@@ -1677,12 +1678,12 @@ public class AuthTest {
 		settings.setLogoutRequestSigned(false);
 
 		Auth auth = new Auth(settings, request, response);
-		String target = auth.logout("", null, null, true);
+		String target = auth.logout("", new LogoutRequestParams(), true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SingleLogoutService.php?SAMLRequest="));
 		assertThat(target, not(containsString("&RelayState=")));
 		
 		String relayState = "http://localhost:8080/expected.jsp";
-		target = auth.logout(relayState, null, null, true);
+		target = auth.logout(relayState, new LogoutRequestParams(), true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SingleLogoutService.php?SAMLRequest="));
 		assertThat(target, containsString("&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp"));
 	}
@@ -2112,7 +2113,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
-		String targetSLOURL = auth.logout(null, null, null, true);
+		String targetSLOURL = auth.logout(null, new LogoutRequestParams(), true);
 		String logoutRequestXML = auth.getLastRequestXML();
 		assertThat(targetSLOURL, containsString(Util.urlEncoder(Util.deflatedBase64encoded(logoutRequestXML))));
 

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -43,20 +43,20 @@ import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Document;
 
 import com.onelogin.saml2.Auth;
+import com.onelogin.saml2.authn.AuthnRequestParams;
 import com.onelogin.saml2.exception.Error;
-import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.exception.SettingsException;
+import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.exception.XMLEntityException;
 import com.onelogin.saml2.model.KeyStoreSettings;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
-
-import org.mockito.ArgumentCaptor;
-import org.w3c.dom.Document;
 
 public class AuthTest {
 
@@ -1381,7 +1381,7 @@ public class AuthTest {
 		Auth auth = new Auth(settings, request, response);
 		Map<String, String> extraParameters = new HashMap<String, String>();
 		extraParameters.put("parameter1", "xxx");
-		String target = auth.login("", false, false, false, true, null, extraParameters);
+		String target = auth.login("", new AuthnRequestParams(false, false, false), true, extraParameters);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		assertThat(target, containsString("&parameter1=xxx"));
 	}
@@ -1410,12 +1410,12 @@ public class AuthTest {
 		settings.setAuthnRequestsSigned(false);
 
 		Auth auth = new Auth(settings, request, response);
-		String target = auth.login("", false, false, false, true);
+		String target = auth.login("", new AuthnRequestParams(false, false, false), true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		assertThat(target, not(containsString("&RelayState=")));
 
 		String relayState = "http://localhost:8080/expected.jsp";
-		target = auth.login(relayState, false, false, false, true);
+		target = auth.login(relayState, new AuthnRequestParams(false, false, false), true);
 		assertThat(target, startsWith("https://pitbulk.no-ip.org/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		assertThat(target, containsString("&RelayState=http%3A%2F%2Flocalhost%3A8080%2Fexpected.jsp"));		
 	}
@@ -1443,13 +1443,13 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
-		String target = auth.login("", false, false, false, true);
+		String target = auth.login("", new AuthnRequestParams(false, false, false), true);
 		assertThat(target, startsWith("http://idp.example.com/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		String authNRequestStr = getSAMLRequestFromURL(target);
 		assertThat(authNRequestStr, containsString("<samlp:AuthnRequest"));
 		assertThat(authNRequestStr, not(containsString("<saml:Subject")));
 
-		target = auth.login("", false, false, false, true, "testuser@example.com");
+		target = auth.login("", new AuthnRequestParams(false, false, false, "testuser@example.com"), true);
 		assertThat(target, startsWith("http://idp.example.com/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		authNRequestStr = getSAMLRequestFromURL(target);
 		assertThat(authNRequestStr, containsString("<samlp:AuthnRequest"));
@@ -1459,7 +1459,7 @@ public class AuthTest {
 
 		settings = new SettingsBuilder().fromFile("config/config.emailaddressformat.properties").build();
 		auth = new Auth(settings, request, response);
-		target = auth.login("", false, false, false, true, "testuser@example.com");
+		target = auth.login("", new AuthnRequestParams(false, false, false, "testuser@example.com"), true);
 		assertThat(target, startsWith("http://idp.example.com/simplesaml/saml2/idp/SSOService.php?SAMLRequest="));
 		authNRequestStr = getSAMLRequestFromURL(target);
 		assertThat(authNRequestStr, containsString("<samlp:AuthnRequest"));
@@ -2086,7 +2086,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
 
 		Auth auth = new Auth(settings, request, response);
-		String targetSSOURL = auth.login(null, false, false, false, true);
+		String targetSSOURL = auth.login(null, new AuthnRequestParams(false, false, false), true);
 		String authNRequestXML = auth.getLastRequestXML();
 		assertThat(targetSSOURL, containsString(Util.urlEncoder(Util.deflatedBase64encoded(authNRequestXML))));
 		


### PR DESCRIPTION
This PR is made of:
- an `AuthRequest` refactoring extracted from #307
- a `LogoutRequest` refactoring picked from my own fork (for which I hadn't provided any PR yet because it was relying on other changes)

Benefits of this refactoring:
- it polishes the `AuthnRequest`, `LogoutRequest` and `Auth` APIs: all those overridings were honestly cluttering the API and they were not easily extensible
- it improves library evolution: any future evolution of this library which requires to add further input parameters to the `AuthnRequest` and `LogoutRequest` generation process, may simply extend `AuthnRequestParams` and `LogoutRequestParams` without the need to further touch the API of  `AuthnRequest`, `LogoutRequest` and `Auth` classes (or to provide even more overridings); this allows, for instance, to implement #329 by simply adding a new property to `AuthnRequestParams` (and of course adjust the generation process) without the need to provide new overloadings
- it improves extensibility: in combination with the `postProcessXml` mechanism introduced in #321 (*), any consumer application which needs to extend this library, may pass to `AuthnRequest` and `LogoutRequest` constructors a proper input params extension, which will also be passed to `postProcessXml`, so that an overriding of the latter will allow for proper XML manipulation and/or extension based on the actual custom input params
- further `Auth` extensibility improvement, which leverages this rafactoring, can be provided: I already anticipated he idea in https://github.com/onelogin/java-saml/issues/265#issuecomment-812631694 and I may provide a separate PR for that if this is accepted and merge
- it clarifies the nature of the different constructors of `LogoutRequest`: the new introduced constructors now are specialized on a single scenario (new outgoing logout request creation vs parsing of an incoming request in an IdP-initiated logout)

The change is 100% backward compatible: all those `Auth.login`, `Auth.logout`, `AuthnRequest` and `LogoutRequest` constructor overloadings have been deprecated (to ease migration), not removed. You may then consider their removal in the future sooner or later, depending on requirements.

(*) Please note that this PR also brings a change in `postProcessXml` API for `AuthnRequest` and `LogoutRequest`, letting it receive the input parameters as well. I think this is fine since the `postProcessXml` has not been released yet, so we should still be on time for this.