### PR TITLE
create deployable WAR of sample project when building via Maven

### DIFF
--- a/samples/java-saml-tookit-jspsample/pom.xml
+++ b/samples/java-saml-tookit-jspsample/pom.xml
@@ -10,6 +10,24 @@
 	<packaging>war</packaging>
 	<name>OneLogin java-saml Toolkit Sample Webapp</name>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<webXml>${webXmlPath}</webXml>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+			</plugin>
+		</plugins>
+	</build>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.onelogin</groupId>
@@ -21,6 +39,11 @@
 			<artifactId>javax.servlet-api</artifactId>
 			<version>4.0.1</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Therefor, I added
- maven-war-plugin execution
- maven-compiler-plugin execution 
    - in case someone want to add and toy around with Java files
- added a slf4j implementation: logback dependency

I think this makes the sample project easier to get started with.