### PR TITLE
Show error in jsp

### DIFF
--- a/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
@@ -4,7 +4,9 @@
 <%@page import="java.util.List"%>
 <%@page import="java.util.Map"%> 
 <%@page import="org.apache.commons.lang3.StringUtils" %>
-<%@ page language="java" contentType="text/html; charset=UTF-8"
+<%@page import="java.io.StringWriter"%>
+<%@page import="java.io.PrintWriter"%>
+<%@page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <!DOCTYPE html>
 <html>
@@ -29,8 +31,23 @@
     	<!--  TODO Session support  --> 
 
 	<%
-		Auth auth = new Auth(request, response);
-		auth.processResponse();
+	    Auth auth;
+        try
+        {
+            auth = new Auth(request, response);
+            auth.processResponse();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            String stackTrace = sw.toString().replace("\n", "<br/>");
+            out.println("<div class=\"alert alert-danger\" role=\"alert\">" + stackTrace + "</div>");
+            return;
+        }
 
 		if (!auth.isAuthenticated()) {
 			out.println("<div class=\"alert alert-danger\" role=\"alert\">Not authenticated</div>");

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/metadata.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/metadata.jsp
@@ -5,7 +5,7 @@ settings.setSPValidationOnly(true);
 List<String> errors = settings.checkSettings();
 
 if (errors.isEmpty()) {
-        String metadata = settings.getSPMetadata();
+    String metadata = settings.getSPMetadata();
 	out.println(metadata);
 } else {
 	response.setContentType("text/html; charset=UTF-8");

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/sls.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/sls.jsp
@@ -2,8 +2,10 @@
 <%@page import="java.util.Collection"%>
 <%@page import="java.util.HashMap"%>
 <%@page import="java.util.List"%>
-<%@page import="java.util.Map"%> 
-<%@ page language="java" contentType="text/html; charset=UTF-8"
+<%@page import="java.util.Map"%>
+<%@page import="java.io.StringWriter"%>
+<%@page import="java.io.PrintWriter"%>
+<%@page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <!DOCTYPE html>
 <html>
@@ -26,9 +28,24 @@
     	<h1>A Java SAML Toolkit by OneLogin demo</h1>
     	<b>Logout</b>   	
 	<%
-		Auth auth = new Auth(request, response);
-		auth.processSLO();
-		
+	    Auth auth;
+        try
+        {
+            auth = new Auth(request, response);
+            auth.processSLO();
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            e.printStackTrace(pw);
+            String stackTrace = sw.toString().replace("\n", "<br/>");
+            out.println("<div class=\"alert alert-danger\" role=\"alert\">" + stackTrace + "</div>");
+            return;
+        }
+
 		List<String> errors = auth.getErrors();
 		
 		if (errors.isEmpty()) {


### PR DESCRIPTION
I was playing around with the sample project and this IdP mock: https://github.com/bjorns/mock-idp

The mock-idp had some minor issues which caused exceptions during authentication.
These exceptions were not immediately visible. I added a try catch to print out such errors.

Of course, in a production environment such errors should be handled more carefully.
However, I think it makes the sample project easier to get started with (when errors occur).