### PR TITLE
Improve SP contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,31 @@ onelogin.saml2.sp.x509certNew =
 # If you have     PKCS#1   BEGIN RSA PRIVATE KEY  convert it by   openssl pkcs8 -topk8 -inform pem -nocrypt -in sp.rsa_key -outform pem -out sp.pem
 onelogin.saml2.sp.privatekey =
 
+# Organization
+onelogin.saml2.organization.name = SP Java 
+onelogin.saml2.organization.displayname = SP Java Example
+onelogin.saml2.organization.url = http://sp.example.com
+onelogin.saml2.organization.lang = en
+
+# Contacts (use indexes to specify multiple contacts, multiple e-mail addresses per contact, multiple phone numbers per contact)
+onelogin.saml2.sp.contact[0].contactType=administrative
+onelogin.saml2.sp.contact[0].company=ACME
+onelogin.saml2.sp.contact[0].given_name=Guy
+onelogin.saml2.sp.contact[0].sur_name=Administrative
+onelogin.saml2.sp.contact[0].email_address[0]=administrative@example.com
+onelogin.saml2.sp.contact[0].email_address[1]=administrative2@example.com
+onelogin.saml2.sp.contact[0].telephone_number[0]=+1-123456789
+onelogin.saml2.sp.contact[0].telephone_number[1]=+1-987654321
+onelogin.saml2.sp.contact[1].contactType=other
+onelogin.saml2.sp.contact[1].company=Big Corp
+onelogin.saml2.sp.contact[1].email_address=info@example.com
+
+# Legacy contacts (legacy way to specify just a technical and a support contact with minimal info) 
+onelogin.saml2.contacts.technical.given_name = Technical Guy
+onelogin.saml2.contacts.technical.email_address = technical@example.com
+onelogin.saml2.contacts.support.given_name = Support Guy
+onelogin.saml2.contacts.support.email_address = support@example.com
+
 ## Identity Provider Data that we want connect with our SP ##
 
 # Identifier of the IdP entity  (must be a URI)
@@ -373,18 +398,6 @@ onelogin.saml2.security.reject_deprecated_alg = true
 # attribute values.
 onelogin.saml2.parsing.trim_name_ids = false
 onelogin.saml2.parsing.trim_attribute_values = false
-
-# Organization
-onelogin.saml2.organization.name = SP Java 
-onelogin.saml2.organization.displayname = SP Java Example
-onelogin.saml2.organization.url = http://sp.example.com
-onelogin.saml2.organization.lang = en
-
-# Contacts
-onelogin.saml2.contacts.technical.given_name = Technical Guy
-onelogin.saml2.contacts.technical.email_address = technical@example.com
-onelogin.saml2.contacts.support.given_name = Support Guy
-onelogin.saml2.contacts.support.email_address = support@example.com
 
 # Prefix used in generated Unique IDs.
 # Optional, defaults to ONELOGIN_ or full ID is like ONELOGIN_ebb0badd-4f60-4b38-b20a-a8e01f0592b1.

--- a/core/src/main/java/com/onelogin/saml2/model/Contact.java
+++ b/core/src/main/java/com/onelogin/saml2/model/Contact.java
@@ -1,5 +1,8 @@
 package com.onelogin.saml2.model;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Contact class of OneLogin's Java Toolkit.
@@ -8,34 +11,78 @@ package com.onelogin.saml2.model;
  */
 public class Contact {
 	/**
-     * Contact type
-     */
+       * Contact type
+       */
 	private final String contactType;
 
 	/**
-     * Contact given name
-     */
+	 * Contact company
+	 */
+	private final String company;
+	
+	/**
+       * Contact given name
+       */
 	private final String givenName;
+	
+	/**
+	 * Contact surname
+	 */
+	private final String surName;
 
 	/**
-     * Contact email
-     */
-	private final String emailAddress;
+       * Contact email
+       */
+	private final List<String> emailAddresses;
+
+	/**
+	 * Contact phone number
+	 */
+	private final List<String> telephoneNumbers;
+	
+	/**
+	 * Constructor to specify minimal contact data.
+	 * <p>
+	 * To maintain backward compatibility, a <code>null</code> given name and a
+	 * <code>null</code> e-mail address are handled as being empty strings.
+	 *
+	 * @param contactType
+	 *              Contact type
+	 * @param givenName
+	 *              Contact given name
+	 * @param emailAddress
+	 *              Contact e-mail
+	 * @deprecated use {@link #Contact(String, String, String, String, List, List)}
+	 */
+	@Deprecated
+	public Contact(String contactType, String givenName, String emailAddress) {
+		this(contactType, null, givenName != null ? givenName : "", null,
+		            Arrays.asList(emailAddress != null ? emailAddress : ""), null);
+	}
 
 	/**
 	 * Constructor
 	 *
 	 * @param contactType
-	 *              String. Contact type
+	 *              Contact type
 	 * @param givenName
-     *				String. Contact given name
-	 * @param emailAddress
-     *				String. Contact email
+	 *              Contact given name
+	 * @param surName
+	 *              Contact surname
+	 * @param company
+	 *              Contact company
+	 * @param emailAddresses
+	 *              Contact e-mails
+	 * @param telephoneNumbers
+	 *              Contact phone numbers
 	 */
-	public Contact(String contactType, String givenName, String emailAddress) {
+	public Contact(String contactType, String company, String givenName, String surName, List<String> emailAddresses, List<String> telephoneNumbers) {
 		this.contactType = contactType != null? contactType : "";
-		this.givenName = givenName != null? givenName : "";
-		this.emailAddress = emailAddress != null? emailAddress : "";
+		this.company = company;
+		this.givenName = givenName;
+		this.surName = surName;
+		this.emailAddresses = emailAddresses != null? emailAddresses: Collections.emptyList();
+		this.telephoneNumbers = telephoneNumbers != null? telephoneNumbers: Collections.emptyList();
 	}
 
 	/**
@@ -46,17 +93,46 @@ public class Contact {
 	}
 
 	/**
-	 * @return string the contact email
+	 * @return the contact email
+	 * @deprecated this returns just the first e-mail address in {@link #getEmailAddresses()}
 	 */
+	@Deprecated
 	public final String getEmailAddress() {
-		return emailAddress;
+		return emailAddresses.size() > 0? emailAddresses.get(0): null;
 	}
 
 	/**
-	 * @return string the contact given name
+	 * @return a list containing the contact e-mail addresses (never <code>null</code>)
+	 */
+	public final List<String> getEmailAddresses() {
+		return emailAddresses;
+	}
+
+	/**
+	 * @return the contact given name
 	 */
 	public final String getGivenName() {
 		return givenName;
 	}
+	
+	/**
+	 * @return the contact surname
+	 */
+	public final String getSurName() {
+		return surName;
+	}
+	
+	/**
+	 * @return the contact company
+	 */
+	public final String getCompany() {
+		return company;
+	}
 
+	/**
+	 * @return a list containing the contact phone numbers (never <code>null</code>)
+	 */
+	public final List<String> getTelephoneNumbers() {
+		return telephoneNumbers;
+	}
 }

--- a/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Metadata.java
@@ -277,8 +277,21 @@ public class Metadata {
 
 		for (Contact contact : contacts) {
 			contactsXml.append("<md:ContactPerson contactType=\"" + Util.toXml(contact.getContactType()) + "\">");
-			contactsXml.append("<md:GivenName>" + Util.toXml(contact.getGivenName()) + "</md:GivenName>");
-			contactsXml.append("<md:EmailAddress>" + Util.toXml(contact.getEmailAddress()) + "</md:EmailAddress>");
+			final String company = contact.getCompany();
+			if(company != null)
+				contactsXml.append("<md:Company>" + Util.toXml(company) + "</md:Company>");
+			final String givenName = contact.getGivenName();
+			if(givenName != null)
+				contactsXml.append("<md:GivenName>" + Util.toXml(givenName) + "</md:GivenName>");
+			final String surName = contact.getSurName();
+			if(surName != null)
+				contactsXml.append("<md:SurName>" + Util.toXml(surName) + "</md:SurName>");
+			final List<String> emailAddresses = contact.getEmailAddresses();
+			emailAddresses.forEach(emailAddress -> contactsXml
+			            .append("<md:EmailAddress>" + Util.toXml(emailAddress) + "</md:EmailAddress>"));
+			final List<String> telephoneNumbers = contact.getTelephoneNumbers();
+			telephoneNumbers.forEach(telephoneNumber -> contactsXml
+			            .append("<md:TelephoneNumber>" + Util.toXml(telephoneNumber) + "</md:TelephoneNumber>"));
 			contactsXml.append("</md:ContactPerson>");
 		}
 

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -9,6 +9,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.onelogin.saml2.model.hsm.HSM;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -1032,7 +1034,10 @@ public class Saml2Settings {
 				}
 */
 
-				if (contact.getEmailAddress().isEmpty() || contact.getGivenName().isEmpty()) {
+				if (contact.getEmailAddresses().isEmpty() || contact.getEmailAddresses().stream().allMatch(StringUtils::isEmpty) || 
+						(StringUtils.isEmpty(contact.getCompany()) && 
+						StringUtils.isEmpty(contact.getGivenName()) && 
+						StringUtils.isEmpty(contact.getSurName()))) {
 					errorMsg = "contact_not_enough_data";
 					errors.add(errorMsg);
 					LOGGER.error(errorMsg);

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -5,8 +5,10 @@ import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import com.onelogin.saml2.model.hsm.HSM;
 
@@ -1017,27 +1019,25 @@ public class Saml2Settings {
 
 		List<Contact> contacts = this.getContacts();
 		if (!contacts.isEmpty()) {
-/*			
-			List<String> validTypes = new ArrayList<String>();
-			validTypes.add("technical");
-			validTypes.add("support");
-			validTypes.add("administrative");
-			validTypes.add("billing");
-			validTypes.add("other");
-*/
+			Set<String> validTypes = new HashSet<>();
+			validTypes.add(Constants.CONTACT_TYPE_TECHNICAL);
+			validTypes.add(Constants.CONTACT_TYPE_SUPPORT);
+			validTypes.add(Constants.CONTACT_TYPE_ADMINISTRATIVE);
+			validTypes.add(Constants.CONTACT_TYPE_BILLING);
+			validTypes.add(Constants.CONTACT_TYPE_OTHER);
 			for (Contact contact : contacts) {
-/*
 				if (!validTypes.contains(contact.getContactType())) {
 					errorMsg = "contact_type_invalid";
 					errors.add(errorMsg);
 					LOGGER.error(errorMsg);
 				}
-*/
-
-				if (contact.getEmailAddresses().isEmpty() || contact.getEmailAddresses().stream().allMatch(StringUtils::isEmpty) || 
-						(StringUtils.isEmpty(contact.getCompany()) && 
-						StringUtils.isEmpty(contact.getGivenName()) && 
-						StringUtils.isEmpty(contact.getSurName()))) {
+				if ((contact.getEmailAddresses().isEmpty()
+				            || contact.getEmailAddresses().stream().allMatch(StringUtils::isEmpty))
+				            && (contact.getTelephoneNumbers().isEmpty() || contact.getTelephoneNumbers()
+				                        .stream().allMatch(StringUtils::isEmpty))
+				            && StringUtils.isEmpty(contact.getCompany())
+				            && StringUtils.isEmpty(contact.getGivenName())
+				            && StringUtils.isEmpty(contact.getSurName())) {
 					errorMsg = "contact_not_enough_data";
 					errors.add(errorMsg);
 					LOGGER.error(errorMsg);

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -15,11 +15,19 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Properties;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +35,7 @@ import com.onelogin.saml2.exception.Error;
 import com.onelogin.saml2.model.Contact;
 import com.onelogin.saml2.model.KeyStoreSettings;
 import com.onelogin.saml2.model.Organization;
+import com.onelogin.saml2.util.Constants;
 import com.onelogin.saml2.util.Util;
 
 /**
@@ -65,6 +74,14 @@ public class SettingsBuilder {
 	public final static String SP_PRIVATEKEY_PROPERTY_KEY = "onelogin.saml2.sp.privatekey";
 	public final static String SP_X509CERTNEW_PROPERTY_KEY = "onelogin.saml2.sp.x509certNew";
 
+	public final static String SP_CONTACT_PROPERTY_KEY_PREFIX = "onelogin.saml2.sp.contact";
+	public final static String SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX = "contactType";
+	public final static String SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX = "company";
+	public final static String SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX = "given_name";
+	public final static String SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX = "sur_name";
+	public final static String SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX = "email_address";
+	public final static String SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX = "telephone_number";
+	
 	// KeyStore
 	public final static String KEYSTORE_KEY = "onelogin.saml2.keystore.store";
 	public final static String KEYSTORE_ALIAS = "onelogin.saml2.keystore.alias";
@@ -112,9 +129,13 @@ public class SettingsBuilder {
 	public final static String PARSING_TRIM_ATTRIBUTE_VALUES = "onelogin.saml2.parsing.trim_attribute_values";
 	
 	// Misc
+	@Deprecated
 	public final static String CONTACT_TECHNICAL_GIVEN_NAME = "onelogin.saml2.contacts.technical.given_name";
+	@Deprecated
 	public final static String CONTACT_TECHNICAL_EMAIL_ADDRESS = "onelogin.saml2.contacts.technical.email_address";
+	@Deprecated
 	public final static String CONTACT_SUPPORT_GIVEN_NAME = "onelogin.saml2.contacts.support.given_name";
+	@Deprecated
 	public final static String CONTACT_SUPPORT_EMAIL_ADDRESS = "onelogin.saml2.contacts.support.email_address";
 
 	public final static String ORGANIZATION_NAME = "onelogin.saml2.organization.name";
@@ -261,7 +282,7 @@ public class SettingsBuilder {
 
 		List<Contact> contacts = this.loadContacts();
 		if (!contacts.isEmpty()) {
-			saml2Setting.setContacts(loadContacts());
+			saml2Setting.setContacts(contacts);
 		}
 
 		Organization org = this.loadOrganization();
@@ -464,15 +485,26 @@ public class SettingsBuilder {
 
 	/**
 	 * Loads the contacts settings from the properties file
+	 * 
+	 * @return a list containing all the loaded contacts
 	 */
+	@SuppressWarnings("deprecation")
 	private List<Contact> loadContacts() {
-		List<Contact> contacts = new LinkedList<>();
-
+		// first split properties into a map of properties
+		// key = contact index; value = contact properties
+		final SortedMap<Integer, Map<String, Object>> contactProps = 
+				extractIndexedProperties(SP_CONTACT_PROPERTY_KEY_PREFIX, samlData);
+		// then build each contact
+		// multiple indexed services specified
+		final List<Contact> contacts = contactProps.entrySet().stream()
+			            .map(entry -> loadContact(entry.getValue(), entry.getKey()))
+			            .collect(Collectors.toList());
+		// append legacy contacts if present
 		String technicalGn = loadStringProperty(CONTACT_TECHNICAL_GIVEN_NAME);
 		String technicalEmailAddress = loadStringProperty(CONTACT_TECHNICAL_EMAIL_ADDRESS);
 
 		if ((technicalGn != null && !technicalGn.isEmpty()) || (technicalEmailAddress != null && !technicalEmailAddress.isEmpty())) {
-			Contact technical = new Contact("technical", technicalGn, technicalEmailAddress);
+			Contact technical = new Contact(Constants.CONTACT_TYPE_TECHNICAL, technicalGn, technicalEmailAddress);
 			contacts.add(technical);
 		}
 
@@ -480,11 +512,183 @@ public class SettingsBuilder {
 		String supportEmailAddress = loadStringProperty(CONTACT_SUPPORT_EMAIL_ADDRESS);
 
 		if ((supportGn != null && !supportGn.isEmpty()) || (supportEmailAddress != null && !supportEmailAddress.isEmpty())) {
-			Contact support = new Contact("support", supportGn, supportEmailAddress);
+			Contact support = new Contact(Constants.CONTACT_TYPE_SUPPORT, supportGn, supportEmailAddress);
 			contacts.add(support);
 		}
 
 		return contacts;
+	}
+
+	/**
+	 * Loads a single contact from settings.
+	 * 
+	 * @param contactProps
+	 *              a map containing the contact settings
+	 * @param index
+	 *              the contact index
+	 * @return the loaded contact
+	 */
+	private Contact loadContact(Map<String, Object> contactProps, int index) {
+		final String contactType =  loadStringProperty(SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX, contactProps);
+		final String company = loadStringProperty(SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX, contactProps);
+		final String givenName = loadStringProperty(SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX, contactProps);
+		final String surName = loadStringProperty(SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX, contactProps);
+		// split properties into a map of properties
+		// key = e-mail address index; value = e-mail address
+		final SortedMap<Integer, Object> emailAddresses = extractIndexedValues(SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX, contactProps);
+		final List<String> emails = toStringList(emailAddresses);
+		// split properties into a map of properties
+		// key = phone number index; value = phone numbers
+		final SortedMap<Integer, Object> phoneNumbers = extractIndexedValues(SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX, contactProps);
+		final List<String> numbers = toStringList(phoneNumbers);
+		return new Contact(contactType, company, givenName, surName, emails, numbers);
+	}
+
+	/**
+	 * Given a map containing settings data, extracts all the indexed properties
+	 * identified by a given prefix. The returned map has indexes as keys and a map
+	 * describing the extracted indexed data as values. Keys are sorted by their
+	 * natural order (i.e. iterating over the map will return entries in index order).
+	 * <p>
+	 * For instance, if the prefix is <code>foo</code>, all the following properties
+	 * will be extracted:
+	 * 
+	 * <pre>
+	 * foo[0].prop1=&lt;value1&gt;
+	 * foo[0].prop2=&lt;value2&gt;
+	 * foo[1].prop1=&lt;value3&gt;
+	 * </pre>
+	 * 
+	 * and the returned map will be:
+	 * 
+	 * <pre>
+	 * 0 => prop1=&lt;value1&gt;
+	 *      prop2=&lt;value2&gt;
+	 * 1 => prop1=&lt;value3&gt;
+	 * </pre>
+	 * 
+	 * The index is optional: if missing, "-1" is returned. In other words, in the
+	 * above example:
+	 * 
+	 * <pre>
+	 * foo.prop1=&lt;value1&gt;
+	 * foo.prop2=&lt;value2&gt;
+	 * </pre>
+	 * 
+	 * will be mapped to:
+	 * 
+	 * <pre>
+	 * -1 => prop1=&lt;value1&gt;
+	 *       prop2=&lt;value2&gt;
+	 * </pre>
+	 * 
+	 * Indices can be made of maximum 9 digits, to prevent overflows. Leading zeroes
+	 * are discarded.
+	 * 
+	 * @param prefix
+	 *              the prefix that identifies the indexed property to extract
+	 * @param data
+	 *              the input data
+	 * @return a map with extracted data for each identified index
+	 */
+	private SortedMap<Integer, Map<String, Object>> extractIndexedProperties(String prefix, Map<String, Object> data) {
+		final Pattern p = Pattern.compile(Pattern.quote(prefix) + 
+				"(?:\\[(\\d{1,9})\\])?\\.(.+)");
+		final SortedMap<Integer, Map<String, Object>> indexedProps = new TreeMap<>();
+		for(final Entry<String, Object> prop: data.entrySet()) {
+			final Matcher m = p.matcher(prop.getKey());
+			if(m.matches()) {
+				final String indexString = m.group(1);
+				final int index = indexString == null? -1: Integer.parseInt(indexString);
+				final String suffix = m.group(2);
+				Map<String, Object> props = indexedProps.get(index);
+				if(props == null) {
+					props = new HashMap<>();
+					indexedProps.put(index, props);
+				}
+				props.put(suffix, prop.getValue());
+			}
+		}
+		return indexedProps;
+	}
+	
+	/**
+	 * Given a map containing settings data, extracts all the indexed values
+	 * identified by a given prefix. The returned map has indexes as keys and the
+	 * corresponding values as values. Keys are sorted by their natural order 
+	 * (i.e. iterating over the map will return entries in index order).
+	 * <p>
+	 * For instance, if the prefix is <code>foo</code>, all the following values
+	 * will be extracted:
+	 * 
+	 * <pre>
+	 * foo[0]=&lt;value1&gt;
+	 * foo[1]=&lt;value2&gt;
+	 * foo[2]=&lt;value3&gt;
+	 * </pre>
+	 * 
+	 * and the returned map will be:
+	 * 
+	 * <pre>
+	 * 0 => &lt;value1&gt;
+	 * 1 => &lt;value2&gt;
+	 * 3 => &lt;value3&gt;
+	 * </pre>
+	 * 
+	 * The index is optional: if missing, "-1" is returned. In other words, in the
+	 * above example:
+	 * 
+	 * <pre>
+	 * foo=&lt;value1&gt;
+	 * </pre>
+	 * 
+	 * will be mapped to:
+	 * 
+	 * <pre>
+	 * -1 => &lt;value1&gt;
+	 * </pre>
+	 * 
+	 * Indices can be made of maximum 9 digits, to prevent overflows. Leading zeroes
+	 * are discarded.
+	 * 
+	 * @param prefix
+	 *              the prefix that identifies the indexed property to extract
+	 * @param data
+	 *              the input data
+	 * @return a map with extracted values for each identified index
+	 */
+	private SortedMap<Integer, Object> extractIndexedValues(String prefix, Map<String, Object> data) {
+		final Pattern p = Pattern.compile(Pattern.quote(prefix) + 
+				"(?:\\[(\\d{1,9})\\])?");
+		final SortedMap<Integer, Object> indexedValues = new TreeMap<>();
+		for(final Entry<String, Object> prop: data.entrySet()) {
+			final Matcher m = p.matcher(prop.getKey());
+			if(m.matches()) {
+				final String indexString = m.group(1);
+				final int index = indexString == null? -1: Integer.parseInt(indexString);
+				indexedValues.put(index, prop.getValue());
+			}
+		}
+		return indexedValues;
+	}
+	
+	/**
+	 * Given a map of indexed property values (possibly extracted with
+	 * {@link #extractIndexedValues(String, Map)}), returns a list containing all
+	 * the {@link String} values contained in the map, sorted by their iteration
+	 * order.
+	 * 
+	 * @param indexedValues
+	 *              a map containing indexed values (key = index; value = actual
+	 *              value)
+	 * @return a list containing all the string values in the input map, sorted by
+	 *         their iteration order; therefore, if the map is a {@link SortedMap},
+	 *         the returned list has values sorted by their index
+	 */
+	private List<String> toStringList(final Map<Integer, Object> indexedValues) {
+		return indexedValues.values().stream()
+		            .map(value -> isString(value) ? StringUtils.trimToNull((String) value) : null)
+		            .filter(Objects::nonNull).collect(Collectors.toList());
 	}
 
 	/**
@@ -568,13 +772,25 @@ public class SettingsBuilder {
 	 * @return the value
 	 */
 	private String loadStringProperty(String propertyKey) {
-		Object propValue = samlData.get(propertyKey);
+		return loadStringProperty(propertyKey, samlData);
+	}
+
+	/**
+	 * Loads a property of the type String from the specified data
+	 *
+	 * @param propertyKey the property name
+	 * @param data the input data
+	 *
+	 * @return the value
+	 */
+	private String loadStringProperty(String propertyKey, Map<String, Object> data) {
+		Object propValue = data.get(propertyKey);
 		if (isString(propValue)) {
 			return StringUtils.trimToNull((String) propValue);
 		}
 		return null;
 	}
-
+	
 	/**
 	 * Loads a property of the type Boolean from the Properties object
 	 *

--- a/core/src/main/java/com/onelogin/saml2/util/Constants.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Constants.java
@@ -83,6 +83,13 @@ public final class Constants {
 	public static final String STATUS_UNKNOWN_PRINCIPAL = "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal";
 	public static final String STATUS_UNSUPPORTED_BINDING = "urn:oasis:names:tc:SAML:2.0:status:UnsupportedBinding";
 
+	// Contact types
+	public static final String CONTACT_TYPE_TECHNICAL = "technical";
+	public static final String CONTACT_TYPE_SUPPORT = "support";
+	public static final String CONTACT_TYPE_ADMINISTRATIVE = "administrative";
+	public static final String CONTACT_TYPE_BILLING = "billing";
+	public static final String CONTACT_TYPE_OTHER = "other";
+
 	// Canonization
 	public static final String C14N = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
 	public static final String C14N_WC = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
@@ -91,7 +98,7 @@ public final class Constants {
 	public static final String C14NEXC = "http://www.w3.org/2001/10/xml-exc-c14n#";
 	public static final String C14NEXC_WC = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
 	
-    // Sign & Crypt   
+      // Sign & Crypt   
 	// https://www.w3.org/TR/xmlenc-core/#sec-Alg-MessageDigest
 	// https://www.w3.org/TR/xmlsec-algorithms/#signature-method-uris
 	// https://tools.ietf.org/html/rfc6931

--- a/core/src/test/java/com/onelogin/saml2/test/settings/IdPMetadataParserTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/IdPMetadataParserTest.java
@@ -236,9 +236,12 @@ public class IdPMetadataParserTest {
 		assertEquals("http://localhost:8080/java-saml-jspsample/metadata.jsp", setting.getSpEntityId());
 		assertEquals(Constants.RSA_SHA512, setting.getSignatureAlgorithm());
 		assertEquals(Constants.SHA512, setting.getDigestAlgorithm());
-		assertEquals(2, setting.getContacts().size());
-		assertEquals("technical@example.com", setting.getContacts().get(0).getEmailAddress());
-		assertEquals("support@example.com", setting.getContacts().get(1).getEmailAddress());
+		assertEquals(4, setting.getContacts().size());
+		assertEquals("administrative@example.com", setting.getContacts().get(0).getEmailAddresses().get(0));
+		assertEquals("administrative2@example.com", setting.getContacts().get(0).getEmailAddresses().get(1));
+		assertEquals("info@example.com", setting.getContacts().get(1).getEmailAddresses().get(0));
+		assertEquals("technical@example.com", setting.getContacts().get(2).getEmailAddresses().get(0));
+		assertEquals("support@example.com", setting.getContacts().get(3).getEmailAddresses().get(0));
 		assertEquals("SP Java", setting.getOrganization().getOrgName());
 		assertEquals("EXAMPLE", setting.getUniqueIDPrefix());
 
@@ -257,9 +260,12 @@ public class IdPMetadataParserTest {
 		assertEquals("http://localhost:8080/java-saml-jspsample/metadata.jsp", setting.getSpEntityId());
 		assertEquals(Constants.RSA_SHA512, setting.getSignatureAlgorithm());
 		assertEquals(Constants.SHA512, setting.getDigestAlgorithm());
-		assertEquals(2, setting.getContacts().size());
-		assertEquals("technical@example.com", setting.getContacts().get(0).getEmailAddress());
-		assertEquals("support@example.com", setting.getContacts().get(1).getEmailAddress());
+		assertEquals(4, setting.getContacts().size());
+		assertEquals("administrative@example.com", setting.getContacts().get(0).getEmailAddresses().get(0));
+		assertEquals("administrative2@example.com", setting.getContacts().get(0).getEmailAddresses().get(1));
+		assertEquals("info@example.com", setting.getContacts().get(1).getEmailAddresses().get(0));
+		assertEquals("technical@example.com", setting.getContacts().get(2).getEmailAddresses().get(0));
+		assertEquals("support@example.com", setting.getContacts().get(3).getEmailAddresses().get(0));
 		assertEquals("SP Java", setting.getOrganization().getOrgName());
 		assertEquals("EXAMPLE", setting.getUniqueIDPrefix());
 

--- a/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/MetadataTest.java
@@ -147,21 +147,24 @@ public class MetadataTest {
 		Metadata metadataObj = new Metadata(settings);
 		String metadataStr = metadataObj.getMetadataString();
 
-		String contactStr = "<md:ContactPerson contactType=\"technical\"><md:GivenName>Technical Guy</md:GivenName><md:EmailAddress>technical@example.com</md:EmailAddress></md:ContactPerson><md:ContactPerson contactType=\"support\"><md:GivenName>Support Guy</md:GivenName><md:EmailAddress>support@example.com</md:EmailAddress></md:ContactPerson>";
-		assertThat(metadataStr, containsString(contactStr));
+		String administrativeContactStr = "<md:ContactPerson contactType=\"administrative\"><md:Company>ACME</md:Company><md:GivenName>Guy</md:GivenName><md:SurName>Administrative</md:SurName><md:EmailAddress>administrative@example.com</md:EmailAddress><md:EmailAddress>administrative2@example.com</md:EmailAddress><md:TelephoneNumber>+1-123456789</md:TelephoneNumber><md:TelephoneNumber>+1-987654321</md:TelephoneNumber></md:ContactPerson>";
+		assertThat(metadataStr, containsString(administrativeContactStr));
+		String otherContactStr = "<md:ContactPerson contactType=\"other\"><md:Company>Big Corp</md:Company><md:EmailAddress>info@example.com</md:EmailAddress></md:ContactPerson>";
+		assertThat(metadataStr, containsString(otherContactStr));
 
 		Saml2Settings settings2 = new SettingsBuilder().fromFile("config/config.min.properties").build();
 		Metadata metadataObj2 = new Metadata(settings2);
 		String metadataStr2 = metadataObj2.getMetadataString();
 
-		assertThat(metadataStr2, not(containsString(contactStr)));
+		assertThat(metadataStr2, not(containsString(administrativeContactStr)));
+		assertThat(metadataStr2, not(containsString(otherContactStr)));
 	}
 
 	/**
 	 * Tests the toContactsXml method of Metadata
 	 * <p>
 	 * Case: contacts text containing special chars.
-	 *
+	 * 
 	 * @throws IOException
 	 * @throws CertificateEncodingException
 	 * @throws Error
@@ -173,8 +176,66 @@ public class MetadataTest {
 		Metadata metadataObj = new Metadata(settings);
 		String metadataStr = metadataObj.getMetadataString();
 
-		String contactStr = "<md:ContactPerson contactType=\"technical\"><md:GivenName>T&amp;chnical Guy</md:GivenName><md:EmailAddress>t&amp;chnical@example.com</md:EmailAddress></md:ContactPerson><md:ContactPerson contactType=\"support\"><md:GivenName>&quot;Support Guy&quot;</md:GivenName><md:EmailAddress>supp&amp;rt@example.com</md:EmailAddress></md:ContactPerson>";
-		assertThat(metadataStr, containsString(contactStr));
+		String administrativeContactStr = "<md:ContactPerson contactType=\"administrative\"><md:Company>ACME &amp; C.</md:Company><md:GivenName>&quot;Guy&quot;</md:GivenName><md:SurName>&lt;Administrative&gt;</md:SurName><md:EmailAddress>administrativ&amp;@example.com</md:EmailAddress><md:EmailAddress>administrativ&amp;2@example.com</md:EmailAddress><md:TelephoneNumber>&lt;+1&gt;-123456789</md:TelephoneNumber><md:TelephoneNumber>&lt;+1&gt;-987654321</md:TelephoneNumber></md:ContactPerson>";
+		assertThat(metadataStr, containsString(administrativeContactStr));
+		String otherContactStr = "<md:ContactPerson contactType=\"other\"><md:Company>Big Corp</md:Company><md:EmailAddress>info@example.com</md:EmailAddress></md:ContactPerson>";
+		assertThat(metadataStr, containsString(otherContactStr));
+
+		Saml2Settings settings2 = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		Metadata metadataObj2 = new Metadata(settings2);
+		String metadataStr2 = metadataObj2.getMetadataString();
+
+		assertThat(metadataStr2, not(containsString(administrativeContactStr)));
+		assertThat(metadataStr2, not(containsString(otherContactStr)));
+	}
+
+	/**
+	 * Tests the toContactsXml method of Metadata with regards to legacy contacts definition
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 * @see com.onelogin.saml2.settings.Metadata#toContactsXml
+	 */
+	@Test
+	public void testToContactsXmlLegacy() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = getSettingFromAllProperties();
+		Metadata metadataObj = new Metadata(settings);
+		String metadataStr = metadataObj.getMetadataString();
+
+		String technicalContactStr = "<md:ContactPerson contactType=\"technical\"><md:GivenName>Technical Guy</md:GivenName><md:EmailAddress>technical@example.com</md:EmailAddress></md:ContactPerson>";
+		assertThat(metadataStr, containsString(technicalContactStr));
+		String supportContactStr = "<md:ContactPerson contactType=\"support\"><md:GivenName>Support Guy</md:GivenName><md:EmailAddress>support@example.com</md:EmailAddress></md:ContactPerson>";
+		assertThat(metadataStr, containsString(supportContactStr));
+
+		Saml2Settings settings2 = new SettingsBuilder().fromFile("config/config.min.properties").build();
+		Metadata metadataObj2 = new Metadata(settings2);
+		String metadataStr2 = metadataObj2.getMetadataString();
+
+		assertThat(metadataStr2, not(containsString(technicalContactStr)));
+		assertThat(metadataStr2, not(containsString(supportContactStr)));
+	}
+
+	/**
+	 * Tests the toContactsXml method of Metadata with regards to legacy contact definition
+	 * <p>
+	 * Case: contacts text containing special chars.
+	 *
+	 * @throws IOException
+	 * @throws CertificateEncodingException
+	 * @throws Error
+	 * @see com.onelogin.saml2.settings.Metadata#toContactsXml
+	 */
+	@Test
+	public void testToContactsXmlLegacySpecialChars() throws IOException, CertificateEncodingException, Error {
+		Saml2Settings settings = getSettingFromAllSpecialCharsProperties();
+		Metadata metadataObj = new Metadata(settings);
+		String metadataStr = metadataObj.getMetadataString();
+
+		String technicalContactStr = "<md:ContactPerson contactType=\"technical\"><md:GivenName>T&amp;chnical Guy</md:GivenName><md:EmailAddress>t&amp;chnical@example.com</md:EmailAddress></md:ContactPerson>";
+		assertThat(metadataStr, containsString(technicalContactStr));
+		String supportContactStr = "<md:ContactPerson contactType=\"support\"><md:GivenName>&quot;Support Guy&quot;</md:GivenName><md:EmailAddress>supp&amp;rt@example.com</md:EmailAddress></md:ContactPerson>";
+		assertThat(metadataStr, containsString(supportContactStr));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
@@ -114,6 +114,7 @@ public class Saml2SettingsTest {
 		assertThat(settingsErrors, hasItem("sp_entityId_not_found"));
 		assertThat(settingsErrors, hasItem("sp_acs_not_found"));
 		assertThat(settingsErrors, hasItem("sp_cert_not_found_and_required"));
+		assertThat(settingsErrors, hasItem("contact_type_invalid"));
 		assertThat(settingsErrors, hasItem("contact_not_enough_data"));
 		assertThat(settingsErrors, hasItem("organization_not_enough_data"));
 	}
@@ -151,6 +152,7 @@ public class Saml2SettingsTest {
 		assertThat(settingsErrors, hasItem("sp_entityId_not_found"));
 		assertThat(settingsErrors, hasItem("sp_acs_not_found"));
 		assertThat(settingsErrors, hasItem("sp_cert_not_found_and_required"));
+		assertThat(settingsErrors, hasItem("contact_type_invalid"));
 		assertThat(settingsErrors, hasItem("contact_not_enough_data"));
 		assertThat(settingsErrors, hasItem("organization_not_enough_data"));
 		assertThat(settingsErrors, hasItem("idp_entityId_not_found"));

--- a/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
@@ -291,15 +291,47 @@ public class SettingBuilderTest {
 		assertTrue(org.equalsTo(setting.getOrganization()));
 
 		List<Contact> contacts = setting.getContacts();
-		assertEquals(2, contacts.size());
+		assertEquals(4, contacts.size());
 		Contact c1 = contacts.get(0);
-		assertEquals("technical", c1.getContactType());
-		assertEquals("technical@example.com", c1.getEmailAddress());
-		assertEquals("Technical Guy", c1.getGivenName());
+		assertEquals("administrative", c1.getContactType());
+		assertEquals("ACME", c1.getCompany());
+		assertEquals("Guy", c1.getGivenName());
+		assertEquals("Administrative", c1.getSurName());
+		assertEquals(2, c1.getEmailAddresses().size());
+		assertEquals("administrative@example.com", c1.getEmailAddresses().get(0));
+		assertEquals("administrative2@example.com", c1.getEmailAddresses().get(1));
+		List<String> c1Phones = c1.getTelephoneNumbers();
+		assertEquals(2, c1Phones.size());
+		assertEquals("+1-123456789", c1Phones.get(0));
+		assertEquals("+1-987654321", c1Phones.get(1));
 		Contact c2 = contacts.get(1);
-		assertEquals("support", c2.getContactType());
-		assertEquals("support@example.com", c2.getEmailAddress());
-		assertEquals("Support Guy", c2.getGivenName());
+		assertEquals("other", c2.getContactType());
+		assertEquals("Big Corp", c2.getCompany());
+		assertNull(c2.getGivenName());
+		assertNull(c2.getSurName());
+		assertEquals(1, c2.getEmailAddresses().size());
+		assertEquals("info@example.com", c2.getEmailAddresses().get(0));
+		assertEquals(0, c2.getTelephoneNumbers().size());
+		Contact c3 = contacts.get(2);
+		assertEquals("technical", c3.getContactType());
+		assertNull(c3.getCompany());
+		assertEquals("Technical Guy", c3.getGivenName());
+		assertNull(c3.getSurName());
+		List<String> c3Emails = c3.getEmailAddresses();
+		assertEquals(1, c3Emails.size());
+		assertEquals("technical@example.com", c3Emails.get(0));
+		assertEquals("technical@example.com", c3.getEmailAddress());
+		assertEquals(0, c3.getTelephoneNumbers().size());
+		Contact c4 = contacts.get(3);
+		assertEquals("support", c4.getContactType());
+		assertNull(c4.getCompany());
+		assertEquals("Support Guy", c4.getGivenName());
+		assertNull(c4.getSurName());
+		List<String> c4Emails = c4.getEmailAddresses();
+		assertEquals(1, c4Emails.size());
+		assertEquals("support@example.com", c4Emails.get(0));
+		assertEquals("support@example.com", c4.getEmailAddress());
+		assertEquals(0, c4.getTelephoneNumbers().size());
 
 		assertEquals("EXAMPLE", setting.getUniqueIDPrefix());
 	}
@@ -753,6 +785,19 @@ public class SettingBuilderTest {
 		samlData.put(ORGANIZATION_LANG, "en");
 
 		// Contacts
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX, "administrative");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX, "ACME");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX, "Guy");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX, "Administrative");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX + "[0]", "administrative@example.com");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX + "[1]", "administrative2@example.com");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX + "[0]", "+1-123456789");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX + "[1]", "+1-987654321");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[1]." + SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX, "other");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[1]." + SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX, "Big Corp");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[1]." + SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX, "info@example.com");
+		
+		// Legacy contacts
 		samlData.put(CONTACT_TECHNICAL_GIVEN_NAME, "Technical Guy");
 		samlData.put(CONTACT_TECHNICAL_EMAIL_ADDRESS, "technical@example.org");
 		samlData.put(CONTACT_SUPPORT_GIVEN_NAME, "Support Guy");
@@ -819,15 +864,48 @@ public class SettingBuilderTest {
 		assertTrue(org.equalsTo(setting.getOrganization()));
 
 		List<Contact> contacts = setting.getContacts();
-		assertEquals(2, contacts.size());
+		assertEquals(4, contacts.size());
 		Contact c1 = contacts.get(0);
-		assertEquals("technical", c1.getContactType());
-		assertEquals("technical@example.org", c1.getEmailAddress());
-		assertEquals("Technical Guy", c1.getGivenName());
+		assertEquals("administrative", c1.getContactType());
+		assertEquals("ACME", c1.getCompany());
+		assertEquals("Guy", c1.getGivenName());
+		assertEquals("Administrative", c1.getSurName());
+		List<String> c1Emails = c1.getEmailAddresses();
+		assertEquals(2, c1Emails.size());
+		assertEquals("administrative@example.com", c1Emails.get(0));
+		assertEquals("administrative2@example.com", c1Emails.get(1));
+		List<String> c1Phones = c1.getTelephoneNumbers();
+		assertEquals(2, c1Phones.size());
+		assertEquals("+1-123456789", c1Phones.get(0));
+		assertEquals("+1-987654321", c1Phones.get(1));
 		Contact c2 = contacts.get(1);
-		assertEquals("support", c2.getContactType());
-		assertEquals("support@example.org", c2.getEmailAddress());
-		assertEquals("Support Guy", c2.getGivenName());
+		assertEquals("other", c2.getContactType());
+		assertEquals("Big Corp", c2.getCompany());
+		assertNull(c2.getGivenName());
+		assertNull(c2.getSurName());
+		List<String> c2Emails = c2.getEmailAddresses();
+		assertEquals(1, c2Emails.size());
+		assertTrue(c2.getTelephoneNumbers().isEmpty());
+		Contact c3 = contacts.get(2);
+		assertEquals("technical", c3.getContactType());
+		assertNull(c3.getCompany());
+		assertEquals("Technical Guy", c3.getGivenName());
+		assertNull(c3.getSurName());
+		List<String> c3Emails = c3.getEmailAddresses();
+		assertEquals(1, c3Emails.size());
+		assertEquals("technical@example.org", c3Emails.get(0));
+		assertEquals("technical@example.org", c3.getEmailAddress());
+		assertTrue(c3.getTelephoneNumbers().isEmpty());
+		Contact c4 = contacts.get(3);
+		assertEquals("support", c4.getContactType());
+		assertNull(c4.getCompany());
+		assertEquals("Support Guy", c4.getGivenName());
+		assertNull(c4.getSurName());
+		List<String> c4Emails = c4.getEmailAddresses();
+		assertEquals(1, c4Emails.size());
+		assertEquals("support@example.org", c4Emails.get(0));
+		assertEquals("support@example.org", c4.getEmailAddress());
+		assertTrue(c4.getTelephoneNumbers().isEmpty());
 
 		assertEquals("_", setting.getUniqueIDPrefix());
 
@@ -917,6 +995,19 @@ public class SettingBuilderTest {
 		samlData.put(ORGANIZATION_LANG, "en");
 
 		// Contacts
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX, "administrative");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX, "ACME");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX, "Guy");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX, "Administrative");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX + "[0]", "administrative@example.com");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX + "[1]", "administrative2@example.com");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX + "[0]", "+1-123456789");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[0]." + SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX + "[1]", "+1-987654321");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[1]." + SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX, "other");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[1]." + SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX, "Big Corp");
+		samlData.put(SP_CONTACT_PROPERTY_KEY_PREFIX + "[1]." + SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX, "info@example.com");
+		
+		// Legacy contacts
 		samlData.put(CONTACT_TECHNICAL_GIVEN_NAME, "Technical Guy");
 		samlData.put(CONTACT_TECHNICAL_EMAIL_ADDRESS, "technical@example.org");
 		samlData.put(CONTACT_SUPPORT_GIVEN_NAME, "Support Guy");
@@ -975,15 +1066,48 @@ public class SettingBuilderTest {
 		assertTrue(org.equalsTo(setting.getOrganization()));
 
 		List<Contact> contacts = setting.getContacts();
-		assertEquals(2, contacts.size());
+		assertEquals(4, contacts.size());
 		Contact c1 = contacts.get(0);
-		assertEquals("technical", c1.getContactType());
-		assertEquals("technical@example.org", c1.getEmailAddress());
-		assertEquals("Technical Guy", c1.getGivenName());
+		assertEquals("administrative", c1.getContactType());
+		assertEquals("ACME", c1.getCompany());
+		assertEquals("Guy", c1.getGivenName());
+		assertEquals("Administrative", c1.getSurName());
+		List<String> c1Emails = c1.getEmailAddresses();
+		assertEquals(2, c1Emails.size());
+		assertEquals("administrative@example.com", c1Emails.get(0));
+		assertEquals("administrative2@example.com", c1Emails.get(1));
+		List<String> c1Phones = c1.getTelephoneNumbers();
+		assertEquals(2, c1Phones.size());
+		assertEquals("+1-123456789", c1Phones.get(0));
+		assertEquals("+1-987654321", c1Phones.get(1));
 		Contact c2 = contacts.get(1);
-		assertEquals("support", c2.getContactType());
-		assertEquals("support@example.org", c2.getEmailAddress());
-		assertEquals("Support Guy", c2.getGivenName());
+		assertEquals("other", c2.getContactType());
+		assertEquals("Big Corp", c2.getCompany());
+		assertNull(c2.getGivenName());
+		assertNull(c2.getSurName());
+		List<String> c2Emails = c2.getEmailAddresses();
+		assertEquals(1, c2Emails.size());
+		assertTrue(c2.getTelephoneNumbers().isEmpty());
+		Contact c3 = contacts.get(2);
+		assertEquals("technical", c3.getContactType());
+		assertNull(c3.getCompany());
+		assertEquals("Technical Guy", c3.getGivenName());
+		assertNull(c3.getSurName());
+		List<String> c3Emails = c3.getEmailAddresses();
+		assertEquals(1, c3Emails.size());
+		assertEquals("technical@example.org", c3Emails.get(0));
+		assertEquals("technical@example.org", c3.getEmailAddress());
+		assertTrue(c3.getTelephoneNumbers().isEmpty());
+		Contact c4 = contacts.get(3);
+		assertEquals("support", c4.getContactType());
+		assertNull(c4.getCompany());
+		assertEquals("Support Guy", c4.getGivenName());
+		assertNull(c4.getSurName());
+		List<String> c4Emails = c4.getEmailAddresses();
+		assertEquals(1, c4Emails.size());
+		assertEquals("support@example.org", c4Emails.get(0));
+		assertEquals("support@example.org", c4.getEmailAddress());
+		assertTrue(c4.getTelephoneNumbers().isEmpty());
 
 		assertEquals("ONELOGIN_", setting.getUniqueIDPrefix());
 	}

--- a/core/src/test/resources/config/config.all.properties
+++ b/core/src/test/resources/config/config.all.properties
@@ -153,6 +153,19 @@ onelogin.saml2.organization.url = http://sp.example.com
 onelogin.saml2.organization.lang = en
 
 # Contacts
+onelogin.saml2.sp.contact[0].contactType=administrative
+onelogin.saml2.sp.contact[0].company=ACME
+onelogin.saml2.sp.contact[0].given_name=Guy
+onelogin.saml2.sp.contact[0].sur_name=Administrative
+onelogin.saml2.sp.contact[0].email_address[0]=administrative@example.com
+onelogin.saml2.sp.contact[0].email_address[1]=administrative2@example.com
+onelogin.saml2.sp.contact[0].telephone_number[0]=+1-123456789
+onelogin.saml2.sp.contact[0].telephone_number[1]=+1-987654321
+onelogin.saml2.sp.contact[1].contactType=other
+onelogin.saml2.sp.contact[1].company=Big Corp
+onelogin.saml2.sp.contact[1].email_address=info@example.com
+
+# Legacy contacts
 onelogin.saml2.contacts.technical.given_name = Technical Guy
 onelogin.saml2.contacts.technical.email_address = technical@example.com
 onelogin.saml2.contacts.support.given_name = Support Guy

--- a/core/src/test/resources/config/config.all_specialchars.properties
+++ b/core/src/test/resources/config/config.all_specialchars.properties
@@ -144,6 +144,19 @@ onelogin.saml2.organization.url = http://sp.example.com?a=1&b=2
 onelogin.saml2.organization.lang = en
 
 # Contacts
+onelogin.saml2.sp.contact[0].contactType=administrative
+onelogin.saml2.sp.contact[0].company=ACME & C.
+onelogin.saml2.sp.contact[0].given_name="Guy"
+onelogin.saml2.sp.contact[0].sur_name=<Administrative>
+onelogin.saml2.sp.contact[0].email_address[0]=administrativ&@example.com
+onelogin.saml2.sp.contact[0].email_address[1]=administrativ&2@example.com
+onelogin.saml2.sp.contact[0].telephone_number[0]=<+1>-123456789
+onelogin.saml2.sp.contact[0].telephone_number[1]=<+1>-987654321
+onelogin.saml2.sp.contact[1].contactType=other
+onelogin.saml2.sp.contact[1].company=Big Corp
+onelogin.saml2.sp.contact[1].email_address=info@example.com
+
+# Legacy contacts
 onelogin.saml2.contacts.technical.given_name = T&chnical Guy
 onelogin.saml2.contacts.technical.email_address = t&chnical@example.com
 onelogin.saml2.contacts.support.given_name = "Support Guy"

--- a/core/src/test/resources/config/config.allerrors.properties
+++ b/core/src/test/resources/config/config.allerrors.properties
@@ -19,4 +19,6 @@ onelogin.saml2.organization.name = SP Java
 onelogin.saml2.organization.url = http://sp.example.com
 
 # Contacts
-onelogin.saml2.contacts.support.email_address = support@example.com
+onelogin.saml2.sp.contact[0].contactType=administrative
+onelogin.saml2.sp.contact[1].contactType=nonexistent
+onelogin.saml2.sp.contact[1].company=ACME

--- a/core/src/test/resources/config/config.sperrors.properties
+++ b/core/src/test/resources/config/config.sperrors.properties
@@ -30,4 +30,6 @@ onelogin.saml2.organization.name = SP Java
 onelogin.saml2.organization.displayname = SP Java Example
 
 # Contacts
-onelogin.saml2.contacts.support.given_name = Support Guy
+onelogin.saml2.sp.contact[0].contactType=administrative
+onelogin.saml2.sp.contact[1].contactType=nonexistent
+onelogin.saml2.sp.contact[1].company=ACME

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -303,7 +303,7 @@ public class AuthTest {
 		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.sperrors.properties").build();
 		
 		expectedEx.expect(SettingsException.class);
-		expectedEx.expectMessage("Invalid settings: sp_entityId_not_found, sp_acs_not_found, sp_cert_not_found_and_required, contact_not_enough_data, organization_not_enough_data, idp_cert_or_fingerprint_not_found_and_required, idp_cert_not_found_and_required");
+		expectedEx.expectMessage("Invalid settings: sp_entityId_not_found, sp_acs_not_found, sp_cert_not_found_and_required, contact_not_enough_data, contact_type_invalid, organization_not_enough_data, idp_cert_or_fingerprint_not_found_and_required, idp_cert_not_found_and_required");
 		new Auth(settings, request, response);
 	}
 


### PR DESCRIPTION
This change adds the ability to specify all data for the Service Provider contacts.

However, it maintains backward compatibility with the old limited support offered for the technical and support contact given name and e-mail address only, although documentation now suggests a more comprehensive approach.

Having the ability to specify rich data for contact types is a key feature required to implement SPID.

This PR also fixes the contact settings validation described in #353.