### PR TITLE
Update parseXML to use XMLErrorAccumulatorHandler

### DIFF
--- a/core/src/main/java/com/onelogin/saml2/util/Util.java
+++ b/core/src/main/java/com/onelogin/saml2/util/Util.java
@@ -394,6 +394,8 @@ public final class Util {
 		} catch (Throwable e) {}
 
 		DocumentBuilder builder = docfactory.newDocumentBuilder();
+		XMLErrorAccumulatorHandler errorAcumulator = new XMLErrorAccumulatorHandler();
+        	builder.setErrorHandler(errorAcumulator);
 		Document doc = builder.parse(inputSource);
 
 		// Loop through the doc and tag every element with an ID attribute


### PR DESCRIPTION
Prevent xerces libraries from outputting to stderr and give users the ability to control logging.