### PR TITLE
Add Settings for Destination URL Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,10 @@ onelogin.saml2.security.allow_duplicated_attribute_name = false
 # (In order to validate the xml, 'strict' and 'wantXMLValidation' must be true).
 onelogin.saml2.security.want_xml_validation = true
 
+# Indicates if the SP will validate 'Destination' attribute in SAML response
+# Both 'strict' and 'wantDestinationUrlValidation' must be true
+onelogin.saml2.security.want_destination_url_validation = true
+
 # Algorithm that the toolkit will use on signing process. Options:
 #  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
 #  'http://www.w3.org/2000/09/xmldsig#dsa-sha1'

--- a/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
+++ b/core/src/main/java/com/onelogin/saml2/authn/SamlResponse.java
@@ -1281,7 +1281,7 @@ public class SamlResponse {
 	 * @throws ValidationError
 	 */
 	protected void validateDestination(final Element element) throws ValidationError {
-		if (element.hasAttribute("Destination")) {
+		if (settings.getWantDestinationUrlValidation() && element.hasAttribute("Destination")) {
 			final String destinationUrl = element.getAttribute("Destination");
 			if (destinationUrl != null) {
 				if (destinationUrl.isEmpty()) {

--- a/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java
@@ -76,6 +76,7 @@ public class Saml2Settings {
 	private List<String> requestedAuthnContext = new ArrayList<>();
 	private String requestedAuthnContextComparison = "exact";
 	private boolean wantXMLValidation = true;
+	private boolean wantDestinationUrlValidation = true;
 	private String signatureAlgorithm = Constants.RSA_SHA1;
 	private String digestAlgorithm = Constants.SHA1;
 	private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
@@ -344,6 +345,13 @@ public class Saml2Settings {
 	 */
 	public boolean getWantXMLValidation() {
 		return wantXMLValidation;
+	}
+
+	/**
+	 * @return the wantDestinationUrlValidation setting value
+	 */
+	public boolean getWantDestinationUrlValidation() {
+		return wantDestinationUrlValidation;
 	}
 
 	/**
@@ -774,6 +782,17 @@ public class Saml2Settings {
 	 */
 	public void setWantXMLValidation(boolean wantXMLValidation) {
 		this.wantXMLValidation = wantXMLValidation;
+	}
+
+	/**
+	 * Set the wantDestinationUrlValidation setting value
+	 *
+	 * @param wantDestinationUrlValidation
+	 * 			the wantDestinationUrlValidation value to be set.
+	 * 			Based on it the SP will validate Destination attribute in SAML response XML.
+	 */
+	public void setDestinationUrlValidation(boolean wantDestinationUrlValidation) {
+		this.wantDestinationUrlValidation = wantDestinationUrlValidation;
 	}
 
 	/**

--- a/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
+++ b/core/src/main/java/com/onelogin/saml2/settings/SettingsBuilder.java
@@ -114,6 +114,7 @@ public class SettingsBuilder {
 	public final static String SECURITY_REQUESTED_AUTHNCONTEXT = "onelogin.saml2.security.requested_authncontext";
 	public final static String SECURITY_REQUESTED_AUTHNCONTEXTCOMPARISON = "onelogin.saml2.security.requested_authncontextcomparison";
 	public final static String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
+	public final static String SECURITY_WANT_DESTINATION_URL_VALIDATION = "onelogin.saml2.security.want_destination_url_validation";
 	public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
 	public final static String SECURITY_DIGEST_ALGORITHM = "onelogin.saml2.security.digest_algorithm";
 	public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO = "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
@@ -398,6 +399,10 @@ public class SettingsBuilder {
 		Boolean wantXMLValidation = loadBooleanProperty(SECURITY_WANT_XML_VALIDATION);
 		if (wantXMLValidation != null)
 			saml2Setting.setWantXMLValidation(wantXMLValidation);
+
+		Boolean wantDestinationUrlvalidation = loadBooleanProperty(SECURITY_WANT_DESTINATION_URL_VALIDATION);
+		if (wantDestinationUrlvalidation != null)
+			saml2Setting.setDestinationUrlValidation(wantDestinationUrlvalidation);
 
 		Boolean signMetadata = loadBooleanProperty(SECURITY_SIGN_METADATA);
 		if (signMetadata != null)

--- a/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/authn/AuthnResponseTest.java
@@ -1946,6 +1946,11 @@ public class AuthnResponseTest {
 		samlResponse.setDestinationUrl(ACS_URL);
 		samlResponse.isValid();
 		assertThat(samlResponse.getError(), not(containsString("The response was received at")));
+
+		settings.setDestinationUrlValidation(false);
+		samlResponse = new SamlResponse(settings, newHttpRequest(requestURL, samlResponseEncoded));
+		samlResponse.isValid();
+		assertThat(samlResponse.getError(), not(containsString("The response was received at")));
 	}
 
 	/**

--- a/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/Saml2SettingsTest.java
@@ -491,4 +491,16 @@ public class Saml2SettingsTest {
 		assertFalse(errors.isEmpty());
 		assertTrue(errors.contains("expired_xml"));
 	}
+
+	/**
+	 * Tests the wantDestinationUrlValidation method of Saml2Settings
+	 */
+	@Test
+	public void testIsWantDestinationUrlValidation() {
+		Saml2Settings settings = new Saml2Settings();
+
+		assertTrue(settings.getWantDestinationUrlValidation());
+		settings.setDestinationUrlValidation(false);
+		assertFalse(settings.getWantDestinationUrlValidation());
+	}
 }

--- a/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
+++ b/core/src/test/java/com/onelogin/saml2/test/settings/SettingBuilderTest.java
@@ -843,6 +843,7 @@ public class SettingBuilderTest {
 		assertTrue(setting.getWantAssertionsSigned());
 		assertTrue(setting.getWantAssertionsEncrypted());
 		assertTrue(setting.getWantNameIdEncrypted());
+		assertTrue(setting.getWantDestinationUrlValidation());
 
 		List<String> reqAuthContext = new ArrayList<>();
 		reqAuthContext.add("urn:oasis:names:tc:SAML:2.0:ac:classes:urn:oasis:names:tc:SAML:2.0:ac:classes:Password");
@@ -925,6 +926,10 @@ public class SettingBuilderTest {
 		assertFalse(previousCert.equals(newCert));
 		assertFalse(previousKey.equals(newKey));
 
+		samlData.put(SECURITY_WANT_DESTINATION_URL_VALIDATION, false);
+
+		setting = new SettingsBuilder().fromValues(samlData).build();
+		assertFalse(setting.getWantDestinationUrlValidation());
 	}
 
 	/**
@@ -1045,6 +1050,7 @@ public class SettingBuilderTest {
 		assertTrue(setting.getWantAssertionsSigned());
 		assertTrue(setting.getWantAssertionsEncrypted());
 		assertTrue(setting.getWantNameIdEncrypted());
+		assertTrue(setting.getWantDestinationUrlValidation());
 
 		List<String> reqAuthContext = new ArrayList<>();
 		reqAuthContext.add("urn:oasis:names:tc:SAML:2.0:ac:classes:urn:oasis:names:tc:SAML:2.0:ac:classes:Password");


### PR DESCRIPTION
Add support to control & optionally disable `Destination` URL validation using a settings flag. The validation is enabled by default to ensure secure by default configuration. However provide an option to the library user to explicitly disable destination URL validation if required.