### PR TITLE
Updated org.apache.santuario:xmlsec to version 2.3.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>org.apache.santuario</groupId>
 			<artifactId>xmlsec</artifactId>
-			<version>2.2.3</version>
+			<version>2.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>


### PR DESCRIPTION
Updating xmlsec to avoid pulling in a version of woodstox-core that is vulnerable to Improper Restriction of XML eXternal Entity (XXE) Reference,