### PR TITLE
Provide compliance with both javax.servlet and jakarta.servlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,23 @@ The toolkit is hosted on github. You can download it from:
 The toolkit is hosted at [Sonatype OSSRH (OSS Repository Hosting)](http://central.sonatype.org/pages/ossrh-guide.html) that is synced to the Central Repository.
 
 Install it as a maven dependency:
+
+To be compliant with JEE 8 (javax.servlet.*):
+```xml
+  <dependency>
+  <groupId>com.onelogin</groupId>
+  <artifactId>java-saml</artifactId>
+  <version>2.9.0</version>
+</dependency>
+```
+
+To be compliant with Jakarta EE 9+ (jakarta.servlet.*):
 ```xml
   <dependency>
       <groupId>com.onelogin</groupId>
       <artifactId>java-saml</artifactId>
       <version>2.9.0</version>
+      <qualifier>jakarta</qualifier>
   </dependency>
 ```
 
@@ -164,7 +176,8 @@ also the [Java Cryptography Extension (JCE)](https://en.wikipedia.org/wiki/Java_
 
 *toolkit:*
 * com.onelogin:java-saml-core
-* javax.servlet:servlet-api
+* javax.servlet:servlet-api (default build `mvn ...`, or with javax profile `mvn -Pjavax ...`)
+* jakarta.servlet:servlet-api (with javax profile `mvn -Pjakarta ...`)
 
 *maven:*
 * org.apache.maven.plugins:maven-jar-plugin
@@ -207,7 +220,7 @@ In the repo, at *src/main/java* you will find the source; at *src/main/resources
 
 
 #### toolkit (com.onelogin:java-saml) ####
-This folder contains a maven project with the Auth class to handle the low level classes of java-saml-core and the ServletUtils class to handle javax.servlet.http objects, used on the Auth class.
+This folder contains a maven project with the Auth class to handle the low level classes of java-saml-core and the ServletUtils class to handle servlet objects (javax.servlet.http with javax profile (default) or jakarta.servlet.http with jakarta profile), used on the Auth class.
 In the repo, at *src/main/java* you will find the source and at *src/test/java* the junit tests for the classes Auth and ServletUtils.
 
 #### samples (com.onelogin:java-saml-tookit-samples) ####
@@ -490,9 +503,9 @@ Auth auth = new Auth(settings, request, response);
 #### The HttpRequest
 java-saml-core uses HttpRequest class, a framework-agnostic representation of an HTTP request.
 
-java-saml depends on javax.servlet:servlet-api, and the classes Auth and ServletUtils use HttpServletRequest and HttpServletResponse objects.
+java-saml depends on javax.servlet:servlet-api (default javax profile) or jakarta.servlet:servlet-api (jakarta profile), and the classes Auth and ServletUtils use HttpServletRequest and HttpServletResponse objects.
 
-If you want to use anything different than javax.servlet.http, you will need to reimplement Auth and ServletUtils based on that new representation of the HTTP request/responses.
+If you want to use anything different than javax.servlet.http or jakarta.servlet.http, you will need to reimplement Auth and ServletUtils based on that new representation of the HTTP request/responses.
 
 #### Initiate SSO
 In order to send an AuthNRequest to the IdP:

--- a/samples/java-saml-tookit-jspsample/pom.xml
+++ b/samples/java-saml-tookit-jspsample/pom.xml
@@ -10,18 +10,55 @@
 	<packaging>war</packaging>
 	<name>OneLogin java-saml Toolkit Sample Webapp</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.onelogin</groupId>
-			<artifactId>java-saml</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>4.0.1</version>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
+	<profiles>
+		<profile>
+			<id>javax</id>
+			<activation>
+				<activeByDefault>true</activeByDefault></activation>
+			<dependencies>
+				<dependency>
+					<groupId>com.onelogin</groupId>
+					<artifactId>java-saml</artifactId>
+					<version>${project.version}</version>
+				</dependency>
 
+				<!-- httprequest and httpresponse with profile javax -->
+				<dependency>
+					<groupId>javax.servlet</groupId>
+					<artifactId>javax.servlet-api</artifactId>
+					<version>4.0.1</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>jakarta</id>
+			<dependencies>
+				<dependency>
+					<groupId>com.onelogin</groupId>
+					<artifactId>java-saml</artifactId>
+					<version>${project.version}</version>
+					<classifier>jakarta</classifier>
+				</dependency>
+
+				<!-- httprequest and httpresponse with profile jakarta -->
+				<dependency>
+					<groupId>jakarta.servlet</groupId>
+					<artifactId>jakarta.servlet-api</artifactId>
+					<version>5.0.0</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-war-plugin</artifactId>
+						<configuration>
+							<classifier>jakarta</classifier>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/toolkit/pom.xml
+++ b/toolkit/pom.xml
@@ -57,14 +57,6 @@
 			<optional>true</optional>
 		</dependency>
 
-		<!-- httprequest and httpresponse -->
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>4.0.1</version>
-			<scope>provided</scope>
-		</dependency>
-
 		<!-- date and time library for Java -->
 		<dependency>
 			<groupId>joda-time</groupId>
@@ -91,6 +83,8 @@
 	</dependencies>
 
 	<build>
+		<sourceDirectory>${src.dir}</sourceDirectory>
+		<testSourceDirectory>${src.test.dir}</testSourceDirectory>
 		<plugins>
 			<plugin>
 				<groupId>org.jacoco</groupId>
@@ -121,6 +115,90 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>javax</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+
+			<properties>
+				<src.dir>${basedir}/src/main/java</src.dir>
+				<src.test.dir>${basedir}/src/test/java</src.test.dir>
+			</properties>
+
+			<dependencies>
+				<!-- httprequest and httpresponse with profile javax -->
+				<dependency>
+					<groupId>javax.servlet</groupId>
+					<artifactId>javax.servlet-api</artifactId>
+					<version>4.0.1</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>jakarta</id>
+
+			<properties>
+				<src.dir>${project.build.directory}/generated-sources/jakarta</src.dir>
+				<src.test.dir>${project.build.directory}/generated-test-sources/jakarta</src.test.dir>
+			</properties>
+
+			<dependencies>
+
+				<!-- httprequest and httpresponse with profile jakarta -->
+				<dependency>
+					<groupId>jakarta.servlet</groupId>
+					<artifactId>jakarta.servlet-api</artifactId>
+					<version>5.0.0</version>
+					<scope>provided</scope>
+				</dependency>
+			</dependencies>
+
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>jakarta-converter</id>
+								<phase>generate-sources</phase>
+								<configuration>
+									<tasks>
+										<mkdir dir="${project.build.directory}/generated-sources/jakarta"/>
+										<mkdir dir="${project.build.directory}/generated-test-sources/jakarta"/>
+
+										<copy todir="${project.build.directory}/generated-sources/jakarta">
+											<fileset dir="${basedir}/src/main/java"/>
+										</copy>
+										<copy todir="${project.build.directory}/generated-test-sources/jakarta">
+											<fileset dir="${basedir}/src/test/java"/>
+										</copy>
+
+										<replace dir="${project.build.directory}/generated-sources/jakarta" token="javax.servlet" value="jakarta.servlet"/>
+										<replace dir="${project.build.directory}/generated-test-sources/jakarta" token="javax.servlet" value="jakarta.servlet"/>
+									</tasks>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<artifactId>maven-jar-plugin</artifactId>
+						<configuration>
+							<classifier>jakarta</classifier>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 <!--
 	<properties>
 		<jacoco.agent.argLine />


### PR DESCRIPTION
Temporary workaround for #349, tested on tomcat 10.

Instead of forking java-saml-toolkit classes or using Eclipse transformer on client side, this PR allows to create 2 jar:
- legacy one (for javax)
- a new one (for jakarta) to reference with `<classifier>jakarta<classifier>`

To build :
- legacy one: `mvn clean install` (`mvn clean install -Pjavax`)
- jakarta one: `mvn clean install -Pjakarta`

I'm not sure how the artifacts are deployed within the release process, i think it should look like this? :
```shell
mvn release:prepare
mvn release:perform
mvn clean install deploy -Prelease
mvn clean install deploy -Prelease,jakarta (may be without release profile here to avoid overwriting sources/javadoc jars?)
mvn release:clean
```

The compliance is achieved within pom.xml metadata and do not modify the original java sources, so you will need to continue using javax to debug with sources.

The javax vs jakarta dependencies are moved under dedicated maven profiles.
- For javax case, that's all
- For jakarta case, we copy all source folders into a temp folder and replace on the fly the javax pkg name by jakarta one, and change the default maven source folders.

Let me know if there is a more efficient way to publish a jakarta compliant jar on central repo.